### PR TITLE
Allow for coexistence with other servers

### DIFF
--- a/examples/ESP8266/ESP8266.ino
+++ b/examples/ESP8266/ESP8266.ino
@@ -65,11 +65,10 @@ void loop() {
   
   // Handle REST calls
   WiFiClient client = server.available();
-  if (!client) {
-    return;
-  }
-  while(!client.available()){
-    delay(1);
+  if (client) {
+    while (!client.available()) {
+      delay(1);
+    }
   }
   rest.handle(client);
  


### PR DESCRIPTION
I think this is better because multiple different servers can coexist this way. I am using it together with an over-the-air update mechanism (OTA) like this:

```
void loop() {
  // Handle REST calls
  WiFiClient client = server.available();
  if (client) {
    while (!client.available()) {
      delay(1);
    }
  }
  rest.handle(client);
  checkOTA();
}
```

With the OTA function being:

```
void checkOTA() {
  if (OTA.parsePacket()) {
    IPAddress remote = OTA.remoteIP();
    int cmd  = OTA.parseInt();
    int port = OTA.parseInt();
    int size   = OTA.parseInt();
    Serial.printf("Update Start: %d\n", size);
    if (!Update.begin(size)) {
      Update.printError(Serial);
      return;
    }
    WiFiClient client;
    if (client.connect(remote, port)) {
      Serial.setDebugOutput(true);
      uint32_t written;
      while (!Update.isFinished()) {
        written = Update.write(client);
        if (written > 0) client.print(written, DEC);
      }
      Serial.setDebugOutput(false);
      if (Update.end()) {
        client.print("OK");
        Serial.printf("Update Success\n");
      } else {
        Update.printError(client);
        Update.printError(Serial);
      }
    } else {
      Serial.printf("Connect Failed\n");
    }
  }
}
```

Note that the OTA mechanism is scheduled to change soon anyway, but I think the change in the `loop()`of the example would make sense anyway.