### PR TITLE
Compatibility with arduino uIP

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -224,6 +224,24 @@ void handle(EthernetClient& client){
   }
 }
 
+// Handle request for the uIP library based on breakouts of the ENC28J60 https://github.com/ntruchsess/arduino_uip
+#elif defined(UIPETHERNET_H)
+void handle(EthernetClient& client){
+
+  if (client.available()) {
+
+    // Handle request
+    handle_proto(client,true,0);
+
+    // Answer
+    sendBuffer(client,50,0);
+    client.stop();  
+   
+    // Reset variables for the next command
+    reset_status();   
+  }
+}
+
 // Handle request for the ESP8266 chip
 #elif defined(ESP8266)
 void handle(WiFiClient& client){


### PR DESCRIPTION
Arduino uIP is a drop-in library for boards based on the ENC28J60. It has the same API as the ethernet.h.
Ethernet example worked flawlessly after adding. Will continue testing.

![capture](https://cloud.githubusercontent.com/assets/6021771/9895439/71d4eb5a-5bf9-11e5-9607-f270c20724c6.PNG)
