### PR TITLE
Digital write includes pin id as field in response

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1072,6 +1072,9 @@ bool send_command(bool headers) {
         addToBuffer(F(" set to "));
         addToBuffer(value);
         addToBuffer(F("\", "));
+		addToBuffer(F("\"pin\": "));
+		addToBuffer(pin);
+		addToBuffer(F(", "));
        }
      }
    }


### PR DESCRIPTION
This will now be present in the json "pin" : 1  much like the when
getting the board info