### PR TITLE
Added support for INPUT_PULLUP

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1118,6 +1118,16 @@ bool send_command(bool headers) {
       if (!LIGHTWEIGHT){addToBuffer(F(" set to input\", "));}
      }
 
+     // Input with pullup
+     if (state == 'I'){
+
+      // Set pin to Input with pullup
+      pinMode(pin,INPUT_PULLUP);
+
+      // Send feedback to client
+      if (!LIGHTWEIGHT){addToBuffer(F(" set to input with pullup\", "));}
+     }
+
      // Output
      if (state == 'o'){
 


### PR DESCRIPTION
I added support for configuring a pin as an input with pullup.

A pin (e.g. pin 8) is configured as an input by typing: /mode/8/i
With my fix/suggestion, a pin can be configured as an input with pullup: /mode/8/I
I chose to use capital "i" to make a distinction between the two types of input configuration.

I verified this on an Arduino Uno.

This might be a valid solution to issue #129.