### PR TITLE
Add url decoding to selected codepaths

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1082,8 +1082,7 @@ void process(char c){
 // Modifies arguments in place
 void urldecode(String &arguments) {
   char a, b;
-  int j = 0;
-  for(int i = 0; i < arguments.length(); i++, j++) {
+  for(int i = 0, int j = 0; i < arguments.length(); i++, j++) {
     // %20 ==> arguments[i] = '%', a = '2', b = '0'
     if ((arguments[i] == '%') && ((a = arguments[i + 1]) && (b = arguments[i + 2])) && (isxdigit(a) && isxdigit(b))) {
       if (a >= 'a') a -= 'a'-'A';

--- a/aREST.h
+++ b/aREST.h
@@ -1078,7 +1078,36 @@ void process(char c){
     }
 }
 
-bool send_command(bool headers) {
+
+// Modifies arguments in place
+void urldecode(String &arguments) {
+  char a, b;
+  int j = 0;
+  for(int i = 0; i < arguments.length(); i++, j++) {
+    // %20 ==> arguments[i] = '%', a = '2', b = '0'
+    if ((arguments[i] == '%') && /*i < arguments.length() - 2 &&*/ ((a = arguments[i + 1]) && (b = arguments[i + 2])) && (isxdigit(a) && isxdigit(b))) {
+      if (a >= 'a') a -= 'a'-'A';
+      if (a >= 'A') a -= ('A' - 10);
+      else          a -= '0';
+
+      if (b >= 'a') b -= 'a'-'A';
+      if (b >= 'A') b -= ('A' - 10);
+      else          b -= '0';
+
+      arguments[j] = char(16 * a + b);
+      i += 2;   // Skip ahead
+    } else if (arguments[i] == '+') {
+      arguments[j] = ' ';
+    } else {
+     arguments[j] = arguments[i];
+    }
+  }
+
+  arguments.remove(j);    // Truncate string to new possibly reduced length
+}
+
+
+bool send_command(bool headers, bool decodeArgs) {
 
    if (DEBUG_MODE) {
 
@@ -1309,6 +1338,9 @@ bool send_command(bool headers) {
   if (command == 'f') {
 
     // Execute function
+    if(decodeArgs)
+      urldecode(arguments);   // Modifies arguments
+
     int result = functions[value](arguments);
 
     // Send feedback to client

--- a/aREST.h
+++ b/aREST.h
@@ -1082,7 +1082,8 @@ void process(char c){
 // Modifies arguments in place
 void urldecode(String &arguments) {
   char a, b;
-  for(int i = 0, int j = 0; i < arguments.length(); i++, j++) {
+  int j = 0;
+  for(int i = 0; i < arguments.length(); i++) {
     // %20 ==> arguments[i] = '%', a = '2', b = '0'
     if ((arguments[i] == '%') && ((a = arguments[i + 1]) && (b = arguments[i + 2])) && (isxdigit(a) && isxdigit(b))) {
       if (a >= 'a') a -= 'a'-'A';
@@ -1100,6 +1101,7 @@ void urldecode(String &arguments) {
     } else {
      arguments[j] = arguments[i];
     }
+    j++;
   }
 
   arguments.remove(j);    // Truncate string to new possibly reduced length

--- a/aREST.h
+++ b/aREST.h
@@ -662,7 +662,7 @@ void handle_proto(char * string) {
   }
 
   // Send command
-  send_command<T>(false, false);
+  send_command(false, false);
 }
 
 template <typename T, typename V>

--- a/aREST.h
+++ b/aREST.h
@@ -347,7 +347,7 @@ void handle(Adafruit_CC3000_ClientRef& client) {
   if (client.available()) {
 
     // Handle request
-    handle_proto(client,true,0);
+    handle_proto(client,true,0,false);
 
     // Answer
     sendBuffer(client,32,20);
@@ -374,7 +374,7 @@ void handle(YunClient& client) {
   if (client.available()) {
 
     // Handle request
-    handle_proto(client,false,0);
+    handle_proto(client,false,0,false);
 
     // Answer
     sendBuffer(client,25,10);
@@ -400,7 +400,7 @@ void handle(Adafruit_BLE_UART& serial) {
   if (serial.available()) {
 
     // Handle request
-    handle_proto(serial,false,0);
+    handle_proto(serial,false,0,false);
 
     // Answer
     sendBuffer(serial,100,1);
@@ -425,7 +425,7 @@ void handle(EthernetClient& client){
   if (client.available()) {
 
     // Handle request
-    handle_proto(client,true,0);
+    handle_proto(client,true,0,false);
 
     // Answer
     sendBuffer(client,50,0);
@@ -451,7 +451,7 @@ void handle(ESP8266Client& client){
   if (client.available()) {
 
     // Handle request
-    handle_proto(client,true,0);
+    handle_proto(client,true,0,true);
 
     // Answer
     sendBuffer(client,0,0);
@@ -482,7 +482,7 @@ void handle(WiFiClient& client){
     }
 
     // Handle request
-    handle_proto(client,true,0);
+    handle_proto(client,true,0,true);
 
     if (DEBUG_MODE) {
       Serial.print("Memory loss after handling:");
@@ -517,7 +517,7 @@ void handle(WiFiClient& client){
     if (DEBUG_MODE) {Serial.println("Request received");}
 
     // Handle request
-    handle_proto(client,true,0);
+    handle_proto(client,true,0,true);
 
     // Answer
     sendBuffer(client,0,0);
@@ -545,7 +545,7 @@ void handle(WiFiClient& client){
     if (DEBUG_MODE) {Serial.println("Request received");}
 
     // Handle request
-    handle_proto(client,true,0);
+    handle_proto(client,true,0,true);
 
     // Answer
     sendBuffer(client,50,1);
@@ -571,7 +571,7 @@ void handle(usb_serial_class& serial){
   if (serial.available()) {
 
     // Handle request
-    handle_proto(serial,false,1);
+    handle_proto(serial,false,1,false);
 
     // Answer
     sendBuffer(serial,25,1);
@@ -596,7 +596,7 @@ void handle(Serial_& serial){
   if (serial.available()) {
 
     // Handle request
-    handle_proto(serial,false,1);
+    handle_proto(serial,false,1,false);
 
     // Answer
     sendBuffer(serial,25,1);
@@ -621,7 +621,7 @@ void handle(HardwareSerial& serial){
   if (serial.available()) {
 
     // Handle request
-    handle_proto(serial,false,1);
+    handle_proto(serial,false,1,false);
 
     // Answer
     sendBuffer(serial,25,1);
@@ -662,7 +662,7 @@ void handle_proto(char * string) {
   }
 
   // Send command
-  send_command(false);
+  send_command<T>(false, false);
 }
 
 template <typename T, typename V>
@@ -691,7 +691,7 @@ void publish_proto(T& client, String eventName, V value) {
 }
 
 template <typename T>
-void handle_proto(T& serial, bool headers, uint8_t read_delay)
+void handle_proto(T& serial, bool headers, uint8_t read_delay, bool decode)
 {
 
   // Check if there is data available to read
@@ -709,7 +709,7 @@ void handle_proto(T& serial, bool headers, uint8_t read_delay)
    }
 
    // Send command
-   send_command(headers);
+   send_command(headers, decode);
 }
 
 #if defined(PubSubClient_h)

--- a/aREST.h
+++ b/aREST.h
@@ -1085,7 +1085,7 @@ void urldecode(String &arguments) {
   int j = 0;
   for(int i = 0; i < arguments.length(); i++, j++) {
     // %20 ==> arguments[i] = '%', a = '2', b = '0'
-    if ((arguments[i] == '%') && /*i < arguments.length() - 2 &&*/ ((a = arguments[i + 1]) && (b = arguments[i + 2])) && (isxdigit(a) && isxdigit(b))) {
+    if ((arguments[i] == '%') && ((a = arguments[i + 1]) && (b = arguments[i + 2])) && (isxdigit(a) && isxdigit(b))) {
       if (a >= 'a') a -= 'a'-'A';
       if (a >= 'A') a -= ('A' - 10);
       else          a -= '0';

--- a/test/testUrlDecode.ino
+++ b/test/testUrlDecode.ino
@@ -1,0 +1,64 @@
+#include <ESP8266WiFi.h>
+#include "aREST.h"
+
+aREST arest;
+int initialMemory;
+
+
+void setup() {
+
+  Serial.begin(115200);
+  Serial.println("\n\nBegin test");
+}
+
+
+bool output = true;
+
+bool test(String test, String expected) {
+    arest.urldecode(test);
+
+    if(output) {
+        Serial.print("|");
+        Serial.print(test);
+        Serial.print("| ");
+        Serial.println(test == expected ? "Pass" : "Fail");
+    }
+
+    return test == expected;
+}
+
+
+int iters = 0;
+
+void loop() {
+    bool passed = 
+        test("Hello+World", "Hello World") &&
+        test("I+love+%25%25%25percents%25%25%25", "I love %%%percents%%%") &&
+        test("", "") &&
+
+        /* Malformed */
+        test("%", "%") &&
+        test("%1", "%1") &&
+        test("I hate percents%", "I hate percents%") &&
+        test("I hate percents%2", "I hate percents%2");
+
+    if(!passed) {
+        Serial.print("TESTS FAILED!");
+    }
+
+    if(iters == 0)
+        initialMemory = ESP.getFreeHeap();
+
+    int memEnd = ESP.getFreeHeap();
+    iters++;
+
+    Serial.printf("%d iterations; Memory loss [[[ %d ]]]\n", iters, memEnd - initialMemory);
+
+    if(output)
+        delay(1500);
+
+    output = false;
+}
+
+
+


### PR DESCRIPTION
Resolves issue I was having calling aREST server from a browser or curl.  Clients were url encoding the parameters, so the server was getting confused.  Different handle() methods are called in different contexts, and it may not always be appropriate to assume url encoding.  I made my best guess as to when this is needed.  Adjust as necessary.

Url decoding happens in place for minimal memory use.

I also included a short .ino sketch to verify the url decoding works as intended.