### PR TITLE
Rename function

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1539,7 +1539,7 @@ void removeLastBufferChar() {
 }
 
 // Add to output buffer
-void addToBuffer(char * toAdd){
+void addToBuffer(const char * toAdd){
 
   if (DEBUG_MODE) {
     #if defined(ESP8266)|| defined (ESP32)

--- a/aREST.h
+++ b/aREST.h
@@ -138,6 +138,23 @@
 
 class aREST {
 
+private:
+struct Variable {
+  virtual void addToBuffer(aREST *arest) const = 0;
+};
+
+
+template<typename T>
+struct TypedVariable: Variable {
+  T *var;
+
+  TypedVariable(T *v) : var{v} { }
+
+  void addToBuffer(aREST *arest) const override { 
+    arest->addToBuffer(*var);
+  }
+};
+
 public:
 
 aREST() {
@@ -162,6 +179,14 @@ aREST(char* rest_remote_server, int rest_port) {
   port = rest_port;
 
 }
+
+template<typename T>
+void variable(const char *name, T *var) { 
+  variables[variables_index] = new TypedVariable<T>(var);
+  variable_names[variables_index] = name;
+  variables_index++;
+}
+
 
 #if defined(_ADAFRUIT_MQTT_FONA_H_)
 
@@ -972,7 +997,7 @@ void process(char c){
 
        // Check if variable name is in int array
        for (uint8_t i = 0; i < variables_index; i++){
-         if(answer.startsWith(int_variables_names[i])) {
+         if(answer.startsWith(variable_names[i])) {
 
            // End here
            pin_selected = true;
@@ -983,38 +1008,6 @@ void process(char c){
            value = i;
          }
        }
-
-       // Check if variable name is in float array (Mega & ESP8266 only)
-       #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-       for (uint8_t i = 0; i < float_variables_index; i++){
-         if(answer.startsWith(float_variables_names[i])) {
-
-           // End here
-           pin_selected = true;
-           state = 'x';
-
-           // Set state
-           command = 'l';
-           value = i;
-         }
-       }
-       #endif
-
-       // Check if variable name is in float array (Mega & ESP8266 only)
-       #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-       for (uint8_t i = 0; i < string_variables_index; i++){
-         if(answer.startsWith(string_variables_names[i])) {
-
-           // End here
-           pin_selected = true;
-           state = 'x';
-
-           // Set state
-           command = 's';
-           value = i;
-         }
-       }
-       #endif
 
        // Check if function name is in array
        for (uint8_t i = 0; i < functions_index; i++){
@@ -1263,47 +1256,18 @@ bool send_command(bool headers) {
   if (command == 'v') {
 
        // Send feedback to client
-       if (LIGHTWEIGHT){addToBuffer(*int_variables[value]);}
+       if (LIGHTWEIGHT){ 
+        variables[value]->addToBuffer(this);
+      }
        else {
         addToBuffer(F("{\""));
-        addToBuffer(int_variables_names[value]);
+        addToBuffer(variable_names[value]);
         addToBuffer(F("\": "));
-        addToBuffer(*int_variables[value]);
+        variables[value]->addToBuffer(this);
         addToBuffer(F(", "));
        }
   }
 
-  // Float ariable selected (Mega only)
-  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-  if (command == 'l') {
-
-       // Send feedback to client
-       if (LIGHTWEIGHT){addToBuffer(*float_variables[value]);}
-       else {
-        addToBuffer(F("{\""));
-        addToBuffer(float_variables_names[value]);
-        addToBuffer(F("\": "));
-        addToBuffer(*float_variables[value]);
-        addToBuffer(F(", "));
-       }
-  }
-  #endif
-
-  // String variable selected (Mega & ESP8266 only)
-  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-  if (command == 's') {
-
-       // Send feedback to client
-       if (LIGHTWEIGHT){addToBuffer(*string_variables[value]);}
-       else {
-        addToBuffer(F("{\""));
-        addToBuffer(string_variables_names[value]);
-        addToBuffer(F("\": \""));
-        addToBuffer(*string_variables[value]);
-        addToBuffer(F("\", "));
-       }
-  }
-  #endif
 
   // Function selected
   if (command == 'f') {
@@ -1384,7 +1348,7 @@ virtual void root_answer() {
     #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H)
 
     // Int variables
-    if (variables_index == 0 && string_variables_index == 0 && float_variables_index == 0){
+    if (variables_index == 0){
       addToBuffer(F(" }, "));
     }
     else {
@@ -1393,35 +1357,13 @@ virtual void root_answer() {
 
         for (uint8_t i = 0; i < variables_index; i++){
           addToBuffer(F("\""));
-          addToBuffer(int_variables_names[i]);
+          addToBuffer(variable_names[i]);
           addToBuffer(F("\": "));
-          addToBuffer(*int_variables[i]);
+          variables[i]->addToBuffer(this);
           addToBuffer(F(", "));
         }
-
       }
-      if (string_variables_index > 0){
 
-        for (uint8_t i = 0; i < string_variables_index; i++){
-          addToBuffer(F("\""));
-          addToBuffer(string_variables_names[i]);
-          addToBuffer(F("\": \""));
-          addToBuffer(*string_variables[i]);
-          addToBuffer(F("\", "));
-        }
-
-      }
-      if (float_variables_index > 0){
-
-        for (uint8_t i = 0; i < float_variables_index; i++){
-          addToBuffer(F("\""));
-          addToBuffer(float_variables_names[i]);
-          addToBuffer(F("\": "));
-          addToBuffer(*float_variables[i]);
-          addToBuffer(F(", "));
-        }
-
-      }
       removeLastBufferChar();
       removeLastBufferChar();
       addToBuffer(F("}, "));
@@ -1433,17 +1375,17 @@ virtual void root_answer() {
 
       for (uint8_t i = 0; i < variables_index-1; i++){
         addToBuffer(F("\""));
-        addToBuffer(int_variables_names[i]);
+        addToBuffer(variable_names[i]);
         addToBuffer(F("\": "));
-        addToBuffer(*int_variables[i]);
+        variables[i]->addToBuffer(this);
         addToBuffer(F(", "));
       }
 
       // End
       addToBuffer(F("\""));
-      addToBuffer(int_variables_names[variables_index-1]);
+      addToBuffer(variable_names[variables_index-1]);
       addToBuffer(F("\": "));
-      addToBuffer(*int_variables[variables_index-1]);
+      variables[variables_index-1]->addToBuffer(this);
       addToBuffer(F("}, "));
     }
     else {
@@ -1466,38 +1408,8 @@ virtual void root_answer() {
   #else
   addToBuffer(F("\", \"connected\": true}\r\n"));
   #endif
-
 }
 
-void variable(char * variable_name, int *variable){
-
-  int_variables[variables_index] = variable;
-  int_variables_names[variables_index] = variable_name;
-  variables_index++;
-
-}
-
-// Float variables (Mega & ESP only, or without CC3000)
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-void variable(char * variable_name, float *variable){
-
-  float_variables[float_variables_index] = variable;
-  float_variables_names[float_variables_index] = variable_name;
-  float_variables_index++;
-
-}
-#endif
-
-// String variables (Mega & ESP only, or without CC3000)
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-void variable(char * variable_name, String *variable){
-
-  string_variables[string_variables_index] = variable;
-  string_variables_names[string_variables_index] = variable_name;
-  string_variables_index++;
-
-}
-#endif
 
 void function(char * function_name, int (*f)(String)){
 
@@ -1898,8 +1810,8 @@ private:
 
   // Int variables arrays
   uint8_t variables_index;
-  int * int_variables[NUMBER_VARIABLES];
-  char * int_variables_names[NUMBER_VARIABLES];
+  Variable* variables[NUMBER_VARIABLES];
+  const char * variable_names[NUMBER_VARIABLES];
 
   // MQTT client
   #if defined(PubSubClient_h)
@@ -1923,19 +1835,6 @@ private:
 
   #endif
 
-  // Float variables arrays (Mega & ESP8266 only)
-  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-  uint8_t float_variables_index;
-  float * float_variables[NUMBER_VARIABLES];
-  char * float_variables_names[NUMBER_VARIABLES];
-  #endif
-
-  // String variables arrays (Mega & ESP8266 only)
-  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H) || defined(ESP32)
-  uint8_t string_variables_index;
-  String * string_variables[NUMBER_VARIABLES];
-  char * string_variables_names[NUMBER_VARIABLES];
-  #endif
 
   // Functions array
   uint8_t functions_index;

--- a/aREST.h
+++ b/aREST.h
@@ -326,10 +326,33 @@ void glow_led() {
 }
 #endif
 
+void addToBufferF(const __FlashStringHelper *toAdd){
+
+  if (DEBUG_MODE) {
+    #if defined(ESP8266)|| defined (ESP32)
+    Serial.print("Memory loss:");
+    Serial.println(freeMemory - ESP.getFreeHeap(),DEC);
+    freeMemory = ESP.getFreeHeap();
+    #endif
+    Serial.print(F("Added to buffer as progmem: "));
+    Serial.println(toAdd);
+  }
+
+  uint8_t idx = 0;
+
+  PGM_P p = reinterpret_cast<PGM_P>(toAdd);
+
+  for ( unsigned char c = pgm_read_byte(p++);
+        c != 0 && index < OUTPUT_BUFFER_SIZE;
+        c = pgm_read_byte(p++), index++) {
+    buffer[index] = c;
+  }
+}
+
 // Send HTTP headers for Ethernet & WiFi
 void send_http_headers(){
 
-  addToBuffer(F("HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST, GET, PUT, OPTIONS\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n"));
+  addToBufferF(F("HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST, GET, PUT, OPTIONS\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n"));
 
 }
 
@@ -1098,7 +1121,7 @@ bool send_command(bool headers) {
 
      // Send feedback to client
      if (!LIGHTWEIGHT){
-       addToBuffer(F("{\"message\": \"Pin D"));
+       addToBufferF(F("{\"message\": \"Pin D"));
        addToBuffer(message_pin);
      }
 
@@ -1109,7 +1132,7 @@ bool send_command(bool headers) {
       pinMode(pin,INPUT);
 
       // Send feedback to client
-      if (!LIGHTWEIGHT){addToBuffer(F(" set to input\", "));}
+      if (!LIGHTWEIGHT){addToBufferF(F(" set to input\", "));}
      }
 
      // Input with pullup
@@ -1119,7 +1142,7 @@ bool send_command(bool headers) {
       pinMode(pin,INPUT_PULLUP);
 
       // Send feedback to client
-      if (!LIGHTWEIGHT){addToBuffer(F(" set to input with pullup\", "));}
+      if (!LIGHTWEIGHT){addToBufferF(F(" set to input with pullup\", "));}
      }
 
      // Output
@@ -1129,7 +1152,7 @@ bool send_command(bool headers) {
        pinMode(pin,OUTPUT);
 
        // Send feedback to client
-       if (!LIGHTWEIGHT){addToBuffer(F(" set to output\", "));}
+       if (!LIGHTWEIGHT){addToBufferF(F(" set to output\", "));}
      }
 
    }
@@ -1144,15 +1167,15 @@ bool send_command(bool headers) {
        // Send answer
        if (LIGHTWEIGHT){addToBuffer(value);}
        else {
-        addToBuffer(F("{\"return_value\": "));
+        addToBufferF(F("{\"return_value\": "));
         addToBuffer(value);
-        addToBuffer(F(", "));
+        addToBufferF(F(", "));
       }
      }
 
      #if !defined(__AVR_ATmega32U4__) || !defined(ADAFRUIT_CC3000_H)
      if (state == 'a') {
-       if (!LIGHTWEIGHT) {addToBuffer(F("{"));}
+       if (!LIGHTWEIGHT) {addToBufferF(F("{"));}
 
        for (uint8_t i = 0; i < NUMBER_DIGITAL_PINS; i++) {
 
@@ -1162,14 +1185,14 @@ bool send_command(bool headers) {
          // Send feedback to client
          if (LIGHTWEIGHT){
            addToBuffer(value);
-           addToBuffer(F(","));
+           addToBufferF(F(","));
          }
          else {
-           addToBuffer(F("\"D"));
+           addToBufferF(F("\"D"));
            addToBuffer(i);
-           addToBuffer(F("\": "));
+           addToBufferF(F("\": "));
            addToBuffer(value);
-           addToBuffer(F(", "));
+           addToBufferF(F(", "));
          }
      }
     }
@@ -1187,11 +1210,11 @@ bool send_command(bool headers) {
 
        // Send feedback to client
        if (!LIGHTWEIGHT){
-        addToBuffer(F("{\"message\": \"Pin D"));
+        addToBufferF(F("{\"message\": \"Pin D"));
         addToBuffer(message_pin);
-        addToBuffer(F(" set to "));
+        addToBufferF(F(" set to "));
         addToBuffer(value);
-        addToBuffer(F("\", "));
+        addToBufferF(F("\", "));
        }
      }
    }
@@ -1206,14 +1229,14 @@ bool send_command(bool headers) {
        // Send feedback to client
        if (LIGHTWEIGHT){addToBuffer(value);}
        else {
-        addToBuffer(F("{\"return_value\": "));
+        addToBufferF(F("{\"return_value\": "));
         addToBuffer(value);
-        addToBuffer(F(", "));
+        addToBufferF(F(", "));
        }
      }
      #if !defined(__AVR_ATmega32U4__)
      if (state == 'a') {
-       if (!LIGHTWEIGHT) {addToBuffer(F("{"));}
+       if (!LIGHTWEIGHT) {addToBufferF(F("{"));}
 
        for (uint8_t i = 0; i < NUMBER_ANALOG_PINS; i++) {
 
@@ -1223,14 +1246,14 @@ bool send_command(bool headers) {
          // Send feedback to client
          if (LIGHTWEIGHT){
            addToBuffer(value);
-           addToBuffer(F(","));
+           addToBufferF(F(","));
          }
          else {
-           addToBuffer(F("\"A"));
+           addToBufferF(F("\"A"));
            addToBuffer(i);
-           addToBuffer(F("\": "));
+           addToBufferF(F("\": "));
            addToBuffer(value);
-           addToBuffer(F(", "));
+           addToBufferF(F(", "));
          }
      }
    }
@@ -1243,29 +1266,28 @@ bool send_command(bool headers) {
      #endif
 
      // Send feedback to client
-     addToBuffer(F("{\"message\": \"Pin D"));
+     addToBufferF(F("{\"message\": \"Pin D"));
      addToBuffer(message_pin);
-     addToBuffer(F(" set to "));
+     addToBufferF(F(" set to "));
      addToBuffer(value);
-     addToBuffer(F("\", "));
+     addToBufferF(F("\", "));
 
    }
   }
 
   // Variable selected
   if (command == 'v') {
-
-       // Send feedback to client
-       if (LIGHTWEIGHT){ 
-        variables[value]->addToBuffer(this);
-      }
-       else {
-        addToBuffer(F("{\""));
-        addToBuffer(variable_names[value]);
-        addToBuffer(F("\": "));
-        variables[value]->addToBuffer(this);
-        addToBuffer(F(", "));
-       }
+    // Send feedback to client 
+    if (LIGHTWEIGHT){  
+      variables[value]->addToBuffer(this); 
+    } 
+    else { 
+      addToBufferF(F("{\"")); 
+      addToBuffer(variable_names[value]); 
+      addToBufferF(F("\": ")); 
+      variables[value]->addToBuffer(this); 
+      addToBufferF(F(", ")); 
+    } 
   }
 
 
@@ -1277,12 +1299,12 @@ bool send_command(bool headers) {
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
-     addToBuffer(F("{\"return_value\": "));
+     addToBufferF(F("{\"return_value\": "));
      addToBuffer(result);
-     addToBuffer(F(", "));
-     //addToBuffer(F(", \"message\": \""));
-     //addToBuffer(functions_names[value]);
-     //addToBuffer(F(" executed\", "));
+     addToBufferF(F(", "));
+     //addToBufferF(F(", \"message\": \""));
+     //addToBufferF(functions_names[value]);
+     //addToBufferF(F(" executed\", "));
     }
   }
 
@@ -1293,25 +1315,24 @@ bool send_command(bool headers) {
   if (command == 'i') {
     if (LIGHTWEIGHT) {addToBuffer(id);}
     else {
-      addToBuffer(F("{"));
+      addToBufferF(F("{"));
     }
   }
 
    // End of message
    if (LIGHTWEIGHT){
-     addToBuffer(F("\r\n"));
+     addToBufferF(F("\r\n"));
    }
 
    else {
-
      if (command != 'r' && command != 'u') {
-       addToBuffer(F("\"id\": \""));
-       addToBuffer(id);
-       addToBuffer(F("\", \"name\": \""));
-       addToBuffer(name);
-       addToBuffer(F("\", \"hardware\": \""));
-       addToBuffer(HARDWARE);
-       addToBuffer(F("\", \"connected\": true}\r\n"));
+      addToBufferF(F("\"id\": \"")); 
+      addToBuffer(id); 
+      addToBufferF(F("\", \"name\": \"")); 
+      addToBuffer(name); 
+      addToBufferF(F("\", \"hardware\": \"")); 
+      addToBuffer(HARDWARE); 
+      addToBufferF(F("\", \"connected\": true}\r\n"));  
      }
    }
 
@@ -1334,7 +1355,7 @@ virtual void root_answer() {
   #if defined(ADAFRUIT_CC3000_H) || defined(ESP8266) || defined(ethernet_h) || defined(WiFi_h)
     #if !defined(PubSubClient_h)
       if (command != 'u') {
-        addToBuffer(F("HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST, GET, PUT, OPTIONS\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n"));
+        addToBufferF(F("HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST, GET, PUT, OPTIONS\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n"));
       }
     #endif
   #endif
@@ -1343,30 +1364,30 @@ virtual void root_answer() {
   else {
 
     // Start
-    addToBuffer(F("{\"variables\": {"));
+    addToBufferF(F("{\"variables\": {"));
 
     #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H)
 
     // Int variables
     if (variables_index == 0){
-      addToBuffer(F(" }, "));
+      addToBufferF(F(" }, "));
     }
     else {
 
       if (variables_index > 0){
 
         for (uint8_t i = 0; i < variables_index; i++){
-          addToBuffer(F("\""));
+          addToBufferF(F("\""));
           addToBuffer(variable_names[i]);
-          addToBuffer(F("\": "));
+          addToBufferF(F("\": "));
           variables[i]->addToBuffer(this);
-          addToBuffer(F(", "));
+          addToBufferF(F(", "));
         }
       }
 
       removeLastBufferChar();
       removeLastBufferChar();
-      addToBuffer(F("}, "));
+      addToBufferF(F("}, "));
 
     }
     #else
@@ -1374,39 +1395,39 @@ virtual void root_answer() {
     if (variables_index > 0){
 
       for (uint8_t i = 0; i < variables_index-1; i++){
-        addToBuffer(F("\""));
+        addToBufferF(F("\""));
         addToBuffer(variable_names[i]);
-        addToBuffer(F("\": "));
+        addToBufferF(F("\": "));
         variables[i]->addToBuffer(this);
-        addToBuffer(F(", "));
+        addToBufferF(F(", "));
       }
 
       // End
-      addToBuffer(F("\""));
+      addToBufferF(F("\""));
       addToBuffer(variable_names[variables_index-1]);
-      addToBuffer(F("\": "));
+      addToBufferF(F("\": "));
       variables[variables_index-1]->addToBuffer(this);
-      addToBuffer(F("}, "));
+      addToBufferF(F("}, "));
     }
     else {
-      addToBuffer(F(" }, "));
+      addToBufferF(F(" }, "));
     }
     #endif
 
   }
 
   // End
-  addToBuffer(F("\"id\": \""));
+  addToBufferF(F("\"id\": \""));
   addToBuffer(id);
-  addToBuffer(F("\", \"name\": \""));
+  addToBufferF(F("\", \"name\": \""));
   addToBuffer(name);
-  addToBuffer(F("\", \"hardware\": \""));
+  addToBufferF(F("\", \"hardware\": \""));
   addToBuffer(HARDWARE);
 
   #if defined(PubSubClient_h)
-  addToBuffer(F("\", \"connected\": true}"));
+  addToBufferF(F("\", \"connected\": true}"));
   #else
-  addToBuffer(F("\", \"connected\": true}\r\n"));
+  addToBufferF(F("\", \"connected\": true}\r\n"));
   #endif
 }
 


### PR DESCRIPTION
Builds off PR #190 (Combine all variable registrations into a single list)

Rename the override of addToBuffer that takes an F() as its argument to addToBufferF().  Getting rid of this override will make my subsequent PR easier to understand and much less disruptive.  This PR should result in no change of behavior beyond what #190 does.