### PR TITLE
Let ESP8266 answer on serial port

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -500,6 +500,22 @@ void handle(WiFiClient& client){
   }
 }
 
+// Handle request on the Serial port
+void handle(HardwareSerial& serial){
+
+  if (serial.available()) {
+
+    // Handle request
+    handle_proto(serial,false,1);
+
+    // Answer
+    sendBuffer(serial,25,1);
+
+    // Reset variables for the next command
+    reset_status();
+  }
+}
+
 template <typename T>
 void publish(WiFiClient& client, String eventName, T value) {
 


### PR DESCRIPTION
My main use for a REST server is provisioning a new device.  Doing so via the serial port is more convenient, since I already have to create a physical connection to load the hardware.  I couldn't see any issues with enabling this, so I did.