### PR TITLE
Break out common code into functions

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -554,7 +554,7 @@ void handle(HardwareSerial& serial){
   if (serial.available()) {
 
     // Handle request
-    handle_proto(serial,false,1);
+    handle_proto(serial,false,1,false);
 
     // Answer
     sendBuffer(serial,25,1);
@@ -1411,7 +1411,7 @@ virtual void root_answer() {
     addToBufferF(F("{\"variables\": {"));
     
     for (uint8_t i = 0; i < variables_index; i++) {
-      addToBuffer(variable_names[i], true);
+      addToBuffer(variable_names[i]);
       addToBufferF(F(": "));
       variables[i]->addToBuffer(this);
 


### PR DESCRIPTION
Reduces repeated code, makes things a tad easier to read.  May reduce memory requirements by reducing the number of embedded strings.  Also streamlines some logic.  Should result in no change in functionality.