### PR TITLE
Support other types

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1611,6 +1611,15 @@ void addToBuffer(int toAdd, bool quotable){
   addToBuffer(number, false);   // Numbers don't get quoted
 }
 
+// Add to output buffer
+void addToBuffer(uint32_t toAdd, bool quotable){
+
+  char number[10];
+  itoa(toAdd,number,10);
+
+  addToBuffer(number, false);   // Numbers don't get quoted
+}
+
 // Add to output buffer (Mega & ESP only)
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H)
 void addToBuffer(float toAdd, bool quotable){

--- a/aREST.h
+++ b/aREST.h
@@ -1599,7 +1599,7 @@ void addToBuffer(uint16_t toAdd, bool quotable){
 
 // Add to output buffer
 void addToBuffer(bool toAdd, bool quotable) {
-  addToBuffer(toAdd ? "True" : "False", false);
+  addToBuffer(toAdd ? "true" : "false", false);
 }
 
 // Add to output buffer

--- a/aREST.h
+++ b/aREST.h
@@ -1598,6 +1598,11 @@ void addToBuffer(uint16_t toAdd, bool quotable){
 }
 
 // Add to output buffer
+void addToBuffer(bool toAdd, bool quotable) {
+  addToBuffer(toAdd ? "True" : "False", false);
+}
+
+// Add to output buffer
 void addToBuffer(int toAdd, bool quotable){
 
   char number[10];


### PR DESCRIPTION
Adds support for boolean and long ints to the variable() command.  This should probably get folded into a template.

This, sadly, builds off #196 (Json quoting).  Merge that one first, and this one will be very simple.