### PR TITLE
Fix weird behavior

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1646,16 +1646,10 @@ void addToBuffer(uint32_t toAdd, bool quotable) {
 }
 
 
-}
-
 // Add to output buffer (Mega & ESP only)
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(CORE_WILDFIRE) || !defined(ADAFRUIT_CC3000_H)
 void addToBuffer(float toAdd, bool quotable){
-
-  char number[10];
-  dtostrf(toAdd, 5, 2, number);
-
-  addToBuffer(number, false);   // Numbers don't get quoted
+  addToBuffer(String(toAdd), false);   // Numbers don't get quoted
 }
 #endif
 

--- a/aREST.h
+++ b/aREST.h
@@ -1626,12 +1626,8 @@ void addToBuffer(const String& toAdd, bool quotable){
 #endif
 
 // Add to output buffer
-void addToBuffer(uint16_t toAdd, bool quotable){
-
-  char number[10];
-  itoa(toAdd,number,10);
-
-  addToBuffer(number, false);   // Numbers don't get quoted
+void addToBuffer(uint16_t toAdd, bool quotable) {
+  addToBuffer(String(toAdd), false);   // Numbers don't get quoted
 }
 
 // Add to output buffer
@@ -1640,21 +1636,16 @@ void addToBuffer(bool toAdd, bool quotable) {
 }
 
 // Add to output buffer
-void addToBuffer(int toAdd, bool quotable){
-
-  char number[10];
-  itoa(toAdd,number,10);
-
-  addToBuffer(number, false);   // Numbers don't get quoted
+void addToBuffer(int toAdd, bool quotable) {
+  addToBuffer(String(toAdd), false);   // Numbers don't get quoted
 }
 
 // Add to output buffer
-void addToBuffer(uint32_t toAdd, bool quotable){
+void addToBuffer(uint32_t toAdd, bool quotable) {
+  addToBuffer(String(toAdd), false);   // Numbers don't get quoted
+}
 
-  char number[10];
-  itoa(toAdd,number,10);
 
-  addToBuffer(number, false);   // Numbers don't get quoted
 }
 
 // Add to output buffer (Mega & ESP only)


### PR DESCRIPTION
I don't understand what was going wrong, but this fixed it.  I think atoi was returning signed ints, even when we wanted unsigned.  Using the String constructor simplifies the code, and is probably about as efficient than creating a buffer and using itoa.