### PR TITLE
Provide access to all passed parameters

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -114,6 +114,19 @@
 #define DEBUG_MODE 0
 #endif
 
+
+// Use AREST_PARAMS_MODE to control how parameters are parsed when using the function() method.
+// Use 0 for standard operation, where everything before the first "=" is stripped before passing the parameter string to the function.
+// Useful for simple functions, where only the value is important
+//    function?params=hello    ==> hello gets passed to the function
+//
+// Use 1 to pass the entire parameter string to the function, which will be responsible for parsing the parameter string
+// Useful for more complex situations, where the key name as well as its value is important, or there are mutliple key-value pairs
+//    function?params=hello    ==> params=hello gets passed to the function
+#ifndef AREST_PARAMS_MODE
+#define AREST_PARAMS_MODE 0
+#endif
+
 // Use light answer mode
 #ifndef LIGHTWEIGHT
 #define LIGHTWEIGHT 0
@@ -1085,9 +1098,17 @@ void process(char c) {
           uint8_t footer_start = answer.length();
           if (answer.endsWith(" HTTP/"))
             footer_start -= 6; // length of " HTTP/"
-          int eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
-          if (eq_position != -1)
-            arguments = answer.substring(eq_position + 1, footer_start);
+
+          // Standard operation --> strip off anything preceeding the first "=", pass the rest to the function
+          if(AREST_PARAMS_MODE == 0) {
+            int eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
+            if (eq_position != -1)
+              arguments = answer.substring(eq_position + 1, footer_start);
+          } 
+          // All params mode --> pass all parameters, if any, to the function.  Function will be resonsible for parsing
+          else if(AREST_PARAMS_MODE == 1) {
+            arguments = answer.substring(header_length + 1, footer_start);
+          }
         }
 
         break; // We found what we're looking for


### PR DESCRIPTION
I need to use more complex query strings that is currently permitted (e.g. /setLedParams?color=xyz&bright=123)

This one was a bit of a conundrum; there are several designs which would achieve the goal of providing access to all parameters, while retaining backwards compatibility and allowing people to use the simplified parameter model provided.

Alternatives considered: 

1. passing a parameter to allow different registrations of function to work differently (aREST.function(xxx, true), aREST.function(yyy, false));

2. two different functions (function() and function2() ?) that provided access to parameters differently; or 

3. (the one I chose) a global setting to change operation of the function feature.

I chose (3) because it seemed cleanest; users will have to parse parameters, and once they have code to do it, they can use it on every use of function().

I am also considering including my code for parsing the function parameters, but it uses STL containers, and thus won't work on all platforms (but does work with ESP8266 and friends).  It would be great if, instead of receiving a string, registered functions could receive an already-parsed parameter list.  I'm not sure of a good way to do that without STL containers.

The code I'm using is here:
https://gist.github.com/eykamp/41179ee60d8f643e2e98f707919e46d5

setLedParamsHandler() is registered with the aREST.function(), and uses the other code to provide a vector of key-value pairs.  It could probably be simplified.
