### PR TITLE
Fix to allow aREST UI to compile

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1645,13 +1645,13 @@ void addStringToBuffer(const char * toAdd, bool quotable){
 // Add to output buffer
 
 template <typename T>
-void addToBuffer(T toAdd, bool quotable) {
+void addToBuffer(T toAdd, bool quotable=false) {
   addStringToBuffer(String(toAdd).c_str(), false);   // Except for our overrides, this will be adding numbers, which don't get quoted
 }
 
 // Register a function instead of a plain old variable!
 template <typename T>
-void addToBuffer(T(*toAdd)(), bool quotable) { 
+void addToBuffer(T(*toAdd)(), bool quotable=true) { 
   addToBuffer(toAdd(), quotable);
 } 
 


### PR DESCRIPTION
Not otherwise tested.  Two changes here -- the fist can have no effect, since the default value is never used.  I haven't got a working setup for aREST UI, so I don't know if the second default should be true or false, but this value shouldn't matter for any aREST code, so pick true or false if one works better than the other.  

Sorry I don't have a good chance to play with aREST UI and figure it out!