### PR TITLE
Always terminate line

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1476,9 +1476,7 @@ virtual void root_answer() {
   // End
   addHardwareToBuffer();
 
-  #ifndef PubSubClient_h
-    addToBufferF(F("\r\n"));
-  #endif
+  addToBufferF(F("\r\n"));
 }
 
 


### PR DESCRIPTION
We should always be terminating the line, unless there is good reason not to.  If we don't clients may not know when the server response is complete.