### PR TITLE
Use bigger int to allow strings longer than 256 chars

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1115,15 +1115,15 @@ void process(char c) {
         // We're expecting a string of the form <functionName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
         // Get command -- Anything following the first '=' in answer will be put in the arguments string.
         arguments = "";
-        uint8_t header_length = strlen(functions_names[i]);
+        uint16_t header_length = strlen(functions_names[i]);
         if (answer.substring(header_length, header_length + 1) == "?") {
-          uint8_t footer_start = answer.length();
+          uint16_t footer_start = answer.length();
           if (answer.endsWith(" HTTP/"))
             footer_start -= 6; // length of " HTTP/"
 
           // Standard operation --> strip off anything preceeding the first "=", pass the rest to the function
           if(AREST_PARAMS_MODE == 0) {
-            int eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
+            uint16_t eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
             if (eq_position != -1)
               arguments = answer.substring(eq_position + 1, footer_start);
           } 


### PR DESCRIPTION
Fixes naughty behavior when parameter strings exceed 256 bytes.