### PR TITLE
Correct ESP8266 Boards Manager URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use the library with Arduino boards you will need the latest version of the A
 To use the library with the ESP8266 WiFi chip you will need to install the required module from the Boards Manager of the Arduino IDE. These are the steps to install the ESP8266 package inside the Arduino IDE:
 
 1. Start the Arduino IDE and open the Preferences window
-2. Enter `http://arduino.esp8266.com/package_esp8266com_index.json` into the Additional Board Manager URLs field. You can add multiple URLs, separating them with commas.
+2. Enter `http://arduino.esp8266.com/stable/package_esp8266com_index.json` into the Additional Board Manager URLs field. You can add multiple URLs, separating them with commas.
 3. Open the Boards Manager from Tools > Board menu and install the esp8266 package (and after that don't forget to select your ESP8266 board from Tools > Board menu).
 
 ### For WiFi using the ESP32 chip


### PR DESCRIPTION
Use the correct Boards Manager URL for installing Arduino ESP8266 Core, as specified in their official installation instructions:
https://github.com/esp8266/Arduino/#installing-with-boards-manager

Fixes https://github.com/marcoschwartz/aREST/issues/230

CC: @jm33-m0