### PR TITLE
only set command if unset

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1138,7 +1138,7 @@ void process(char c) {
     }
 
     // If the command is "id", return device id, name and status
-    if ((answer[0] == 'i' && answer[1] == 'd')) {
+    if (command == 'u' && (answer[0] == 'i' && answer[1] == 'd')) {
 
       // Set state
       command = 'i';
@@ -1148,7 +1148,7 @@ void process(char c) {
       state = 'x';
     }
 
-    if (answer[0] == ' ') {
+    if (command == 'u' && answer[0] == ' ') {
 
       // Set state
       command = 'r';


### PR DESCRIPTION
Hi,
if you don't like the changes, don't mind and simply close this pull request 😄 

If a variable or function `ident` is registerd, only the root answer function gets called, and the variable or function `ident` is ignored, because it starts also with `id` as the `id` command.