### PR TITLE
Feature/handlers

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -133,6 +133,36 @@
 #define LIGHTWEIGHT 0
 #endif
 
+
+// -------- for backwards compatibility --------
+#ifdef AREST_NUMBER_VARIABLES
+#define NUMBER_VARIABLES AREST_NUMBER_VARIABLES
+#endif
+
+#ifdef AREST_NUMBER_FUNCTIONS
+#define NUMBER_FUNCTIONS AREST_NUMBER_FUNCTIONS
+#endif
+
+#if defined(NUMBER_VARIABLES) && defined(NUMBER_FUNCTIONS)
+  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
+#elif defined(NUMBER_VARIABLES)
+  #if defined(__AVR_ATmega1280__) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)
+  #define NUMBER_FUNCTIONS 10
+  #else
+  #define NUMBER_FUNCTIONS 5
+  #endif
+  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
+#elif defined(NUMBER_FUNCTIONS)
+  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
+  #define NUMBER_VARIABLES 10
+  #else
+  #define NUMBER_VARIABLES 5
+  #endif
+  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
+#endif
+// -------- end --------
+
+
 #ifdef AREST_NUMBER_HANDLERS
 #define NUMBER_HANDLERS AREST_NUMBER_HANDLERS
 #endif

--- a/aREST.h
+++ b/aREST.h
@@ -204,9 +204,8 @@ struct FunctionHandler: Handler {
     int result = func(arguments);
 
     if (!LIGHTWEIGHT) {
-      arest->addToBufferF(F("{\"return_value\": "));
+      arest->addToBufferF(F("\"return_value\": "));
       arest->addToBuffer(result, true);
-      arest->addToBufferF(F(", "));
       // arest->addToBufferF(F(", \"message\": \""));
       // arest->addStringToBuffer(name.c_str());
       // arest->addToBufferF(F(" executed\", "));

--- a/aREST.h
+++ b/aREST.h
@@ -133,29 +133,16 @@
 #define LIGHTWEIGHT 0
 #endif
 
-#ifdef AREST_NUMBER_VARIABLES
-#define NUMBER_VARIABLES AREST_NUMBER_VARIABLES
-#endif
-
-#ifdef AREST_NUMBER_FUNCTIONS
-#define NUMBER_FUNCTIONS AREST_NUMBER_FUNCTIONS
+#ifdef AREST_NUMBER_HANDLERS
+#define NUMBER_HANDLERS AREST_NUMBER_HANDLERS
 #endif
 
 // Default number of max. exposed variables
-#ifndef NUMBER_VARIABLES
+#ifndef NUMBER_HANDLERS
   #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
-  #define NUMBER_VARIABLES 10
+  #define NUMBER_HANDLERS 20
   #else
-  #define NUMBER_VARIABLES 5
-  #endif
-#endif
-
-// Default number of max. exposed functions
-#ifndef NUMBER_FUNCTIONS
-  #if defined(__AVR_ATmega1280__) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)
-  #define NUMBER_FUNCTIONS 10
-  #else
-  #define NUMBER_FUNCTIONS 5
+  #define NUMBER_HANDLERS 10
   #endif
 #endif
 
@@ -168,13 +155,29 @@
 class aREST {
 
 private:
-struct Variable {
-  virtual void addToBuffer(aREST *arest) const = 0;
+struct Handler {
+  virtual void addToBuffer(aREST *arest, const String& name, const String& arguments) const = 0;
 };
 
 
-template<typename T>
-struct TypedVariable: Variable {
+template<bool INCLUDE_INTO_ROOT_ANSWER>
+struct RootVariable: Handler {
+  virtual void addToBuffer(aREST *arest) const = 0;
+
+  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+    if (LIGHTWEIGHT) {
+      addToBuffer(arest);
+    } else {
+      arest->addStringToBuffer(name.c_str(), true);
+      arest->addToBufferF(F(": "));
+      addToBuffer(arest);
+    }
+  }
+};
+
+
+template<typename T, bool INCLUDE_INTO_ROOT_ANSWER>
+struct TypedVariable: RootVariable<INCLUDE_INTO_ROOT_ANSWER> {
   T *var;
   bool quotable;
 
@@ -183,6 +186,26 @@ struct TypedVariable: Variable {
   void addToBuffer(aREST *arest) const override { 
     arest->addToBuffer(*var, quotable);
   }  
+};
+
+
+struct FunctionHandler: Handler {
+  int (*func)(String);
+
+  FunctionHandler(int (*f)(String)) : func{f} { }
+
+  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+    int result = func(arguments);
+
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("{\"return_value\": "));
+      arest->addToBuffer(result, true);
+      arest->addToBufferF(F(", "));
+      // arest->addToBufferF(F(", \"message\": \""));
+      // arest->addStringToBuffer(name.c_str());
+      // arest->addToBufferF(F(" executed\", "));
+    }
+  }
 };
 
 public:
@@ -209,14 +232,21 @@ aREST(char* rest_remote_server, int rest_port) {
 
 template<typename T>
 void variable(const char *name, T *var, bool quotable) { 
-  variables[variables_index] = new TypedVariable<T>(var, quotable);
-  variable_names[variables_index] = name;
-  variables_index++;
+  handlers[handlers_index] = new TypedVariable<T, true>(var, quotable);
+  handler_names[handlers_index] = name;
+  handlers_index++;
 }
 
 template<typename T>
 void variable(const char *name, T *var) { 
   variable(name, var, true);
+}
+
+
+void function(const char *name, int (*f)(String)) {
+  handlers[handlers_index] = new FunctionHandler(f);
+  handler_names[handlers_index] = name;
+  handlers_index++;
 }
 
 
@@ -1079,55 +1109,39 @@ void process(char c) {
     #endif
   }
 
-  // Variable or function request received ?
+  // Handler request received ?
   if (command == 'u') {
 
-    // Check if variable name is in int array
-    for (uint8_t i = 0; i < variables_index; i++) {
-      if (answer.startsWith(variable_names[i])) {
+    // Check if handler name is register in array
+    for (uint8_t i = 0; i < handlers_index; i++) {
+      if (answer.startsWith(handler_names[i])) {
 
         // End here
         pin_selected = true;
         state = 'x';
 
         // Set state
-        command = 'v';
-        value = i;
-
-        break; // We found what we're looking for
-      }
-    }
-
-    // Check if function name is in array
-    for (uint8_t i = 0; i < functions_index; i++) {
-      if (answer.startsWith(functions_names[i])) {
-
-        // End here
-        pin_selected = true;
-        state = 'x';
-
-        // Set state
-        command = 'f';
+        command = 'h';
         value = i;
 
         answer.trim();
 
-        // We're expecting a string of the form <functionName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
+        // We're expecting a string of the form <handlerName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
         // Get command -- Anything following the first '=' in answer will be put in the arguments string.
         arguments = "";
-        uint16_t header_length = strlen(functions_names[i]);
+        uint16_t header_length = strlen(handler_names[i]);
         if (answer.substring(header_length, header_length + 1) == "?") {
           uint16_t footer_start = answer.length();
           if (answer.endsWith(" HTTP/"))
             footer_start -= 6; // length of " HTTP/"
 
-          // Standard operation --> strip off anything preceeding the first "=", pass the rest to the function
+          // Standard operation --> strip off anything preceeding the first "=", pass the rest to the handler
           if(AREST_PARAMS_MODE == 0) {
             uint16_t eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
             if (eq_position != -1)
               arguments = answer.substring(eq_position + 1, footer_start);
           } 
-          // All params mode --> pass all parameters, if any, to the function.  Function will be resonsible for parsing
+          // All params mode --> pass all parameters, if any, to the handler.  Handler will be resonsible for parsing
           else if(AREST_PARAMS_MODE == 1) {
             arguments = answer.substring(header_length + 1, footer_start);
           }
@@ -1396,34 +1410,18 @@ bool send_command(bool headers, bool decodeArgs) {
     }
   }
 
-  // Variable selected
-  if (command == 'v') {
+  // Handler selected
+  if (command == 'h') {
+    if (decodeArgs) {
+      urldecode(arguments); // Modifies arguments
+    }
     // Send feedback to client
     if (LIGHTWEIGHT) {
-      variables[value]->addToBuffer(this);
+      addHandlerToBuffer(value, arguments);
     } else {
       addToBufferF(F("{"));
-      addVariableToBuffer(value);
-    }
-  }
-
-  // Function selected
-  if (command == 'f') {
-
-    // Execute function
-    if (decodeArgs)
-      urldecode(arguments); // Modifies arguments
-
-    int result = functions[value](arguments);
-
-    // Send feedback to client
-    if (!LIGHTWEIGHT) {
-      addToBufferF(F("{\"return_value\": "));
-      addToBuffer(result, true);
+      addHandlerToBuffer(value, arguments);
       addToBufferF(F(", "));
-      // addToBufferF(F(", \"message\": \""));
-      // addToBufferF(functions_names[value]);
-      // addToBufferF(F(" executed\", "));
     }
   }
 
@@ -1482,13 +1480,16 @@ virtual void root_answer() {
   else {
     addToBufferF(F("{\"variables\": {"));
 
-    for (uint8_t i = 0; i < variables_index; i++){
-      addStringToBuffer(variable_names[i], true);
-      addToBufferF(F(": "));
-      variables[i]->addToBuffer(this);
-
-      if (i < variables_index - 1) {
-        addToBufferF(F(", "));
+    bool isFirst = true;
+    for (uint8_t i = 0; i < handlers_index; i++){
+      if (dynamic_cast<RootVariable<true>*>(handlers[i])) {
+        // variable should be included into root answer
+        if (isFirst) {
+          isFirst = false;
+        } else {
+          addToBufferF(F(", "));
+        }
+        addHandlerToBuffer(i, String(""));
       }
     }
 
@@ -1503,13 +1504,6 @@ virtual void root_answer() {
   #endif
 }
 
-
-void function(char * function_name, int (*f)(String)){
-
-  functions_names[functions_index] = function_name;
-  functions[functions_index] = f;
-  functions_index++;
-}
 
 // Set device ID
 void set_id(const String& device_id) {
@@ -1842,11 +1836,8 @@ uint8_t esp_12_pin_map(uint8_t pin) {
 }
 
 
-void addVariableToBuffer(uint8_t index) {
-  addStringToBuffer(variable_names[index], true);
-  addToBufferF(F(": "));
-  variables[index]->addToBuffer(this);
-  addToBufferF(F(", "));
+void addHandlerToBuffer(uint8_t index, const String& arguments) {
+  handlers[index]->addToBuffer(this, String(handler_names[index]), arguments);
 }
 
 
@@ -1907,10 +1898,10 @@ private:
   // Status LED
   uint8_t status_led_pin;
 
-  // Int variables arrays
-  uint8_t variables_index;
-  Variable* variables[NUMBER_VARIABLES];
-  const char * variable_names[NUMBER_VARIABLES];
+  // Handlers arrays
+  uint8_t handlers_index;
+  Handler* handlers[NUMBER_HANDLERS];
+  const char * handler_names[NUMBER_HANDLERS];
 
   // MQTT client
   #if defined(PubSubClient_h)
@@ -1931,11 +1922,6 @@ private:
 
   #endif
 
-
-  // Functions array
-  uint8_t functions_index;
-  int (*functions[NUMBER_FUNCTIONS])(String);
-  char * functions_names[NUMBER_FUNCTIONS];
 
   // Memory debug
   #if defined(ESP8266) || defined(ESP32)

--- a/aREST.h
+++ b/aREST.h
@@ -137,7 +137,7 @@
 #define NUMBER_HANDLERS AREST_NUMBER_HANDLERS
 #endif
 
-// Default number of max. exposed variables
+// Default number of max. exposed handlers
 #ifndef NUMBER_HANDLERS
   #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
   #define NUMBER_HANDLERS 20

--- a/aREST.h
+++ b/aREST.h
@@ -1144,7 +1144,7 @@ void process(char c) {
   // Handler request received ?
   if (command == 'u') {
 
-    // Check if handler name is register in array
+    // Check if handler name is registered in array
     for (uint8_t i = 0; i < handlers_index; i++) {
       if (answer.startsWith(handler_names[i])) {
 


### PR DESCRIPTION
Hi,
if you don't like the changes, don't mind and simply close this pull request 😄 

If the pull requests #236 and/or #237 are merged before, this pull request will cause a merge conflict. So if the other two pull requests are merged, I'll update this branch to merge cleanly into master 😅 

`variables` and `functions` are generalized into `handlers` (because later I'd like to add another `handler` called `api_extension`).

The backwards compatibility is kepts through some makros:
```
// -------- for backwards compatibility --------
#ifdef AREST_NUMBER_VARIABLES
#define NUMBER_VARIABLES AREST_NUMBER_VARIABLES
#endif

#ifdef AREST_NUMBER_FUNCTIONS
#define NUMBER_FUNCTIONS AREST_NUMBER_FUNCTIONS
#endif

#if defined(NUMBER_VARIABLES) && defined(NUMBER_FUNCTIONS)
  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
#elif defined(NUMBER_VARIABLES)
  #if defined(__AVR_ATmega1280__) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)
  #define NUMBER_FUNCTIONS 10
  #else
  #define NUMBER_FUNCTIONS 5
  #endif
  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
#elif defined(NUMBER_FUNCTIONS)
  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
  #define NUMBER_VARIABLES 10
  #else
  #define NUMBER_VARIABLES 5
  #endif
  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
#endif
// -------- end --------
```

Also the API of the library is the same as before:
```
template<typename T>
void variable(const char *name, T *var, bool quotable);

void function(const char *name, int (*f)(String));
```