### PR TITLE
Feature/controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ You can also define your own functions in your sketch that can be called using t
 
 ### API-Extensions
 
-You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& command)`. For example, if your aREST instance is called "rest" and the function "temperaturesController":
-  * `rest.api_extension("temperatures",temperaturesController);` declares the api extension in the Arduino sketch
-  * `/temperatures/set_limit/lower?value=3` executes the api-extionsion function
+You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& command)`. For example, if your aREST instance is called "rest" and the function "aquariumController":
+  * `rest.api_extension("aquarium",aquariumController);` declares the api extension in the Arduino sketch
+  * `/aquarium/water_limit/lower/set/65` executes the api-extionsion function
 
 ### Get data about the board
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To install the library, simply clone this repository in the /libraries folder of
 
 ## API documentation
 
-The API currently supports five type of commands: digital, analog, and mode, variables, and user-defined functions.
+The API currently supports five type of commands: digital, analog, and mode, variables, and user-defined functions and api-extensions.
 
 ### Digital
 
@@ -188,6 +188,12 @@ To access a variable in your sketch, you have to declare it first, and then call
 You can also define your own functions in your sketch that can be called using the REST API. To access a function defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all functions needs to take a String as the unique argument (for parameters to be passed to the function) and return an integer. For example, if your aREST instance is called "rest" and the function "ledControl":
   * `rest.function("led",ledControl);` declares the function in the Arduino sketch
   * `/led?params=0` executes the function
+
+### API-Extensions
+
+You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& command)`. For example, if your aREST instance is called "rest" and the function "temperaturesController":
+  * `rest.api_extension("temperatures",temperaturesController);` declares the api extension in the Arduino sketch
+  * `/temperatures/set_limit/lower?value=3` executes the api-extionsion function
 
 ### Get data about the board
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,21 @@ You can also define your own functions in your sketch that can be called using t
 
 ### API-Extensions
 
-You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& request_url)`. For example, if your aREST instance is called "rest" and the function "aquariumController":
+With api-extensions you have the possibility to extend the api by your own subcommands and customized responses.
+
+You define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& request_url)`. For example, if your aREST instance is called "rest" and the function "aquariumController":
   * `rest.api_extension("aquarium",aquariumController);` declares the api extension in the Arduino sketch
   * `/aquarium/water_limit/lower/set/65` executes the api-extension function and passes the value `"/aquarium/water_limit/lower/set/65"` as the third parameter (`request_url`) into the api-extension function
+  * You can then customize your JSON result and extend it to something like this:
+    ```
+    {
+        "sensor-ids": ["100", "101", "102", "103", "104"],
+        "id": "008",
+        "name": "dapper_drake",
+        "hardware": "arduino",
+        "connected": true
+    }
+    ```
 
 ### Get data about the board
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can also define your own functions in your sketch that can be called using t
 
 You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& request_url)`. For example, if your aREST instance is called "rest" and the function "aquariumController":
   * `rest.api_extension("aquarium",aquariumController);` declares the api extension in the Arduino sketch
-  * `/aquarium/water_limit/lower/set/65` executes the api-extionsion function
+  * `/aquarium/water_limit/lower/set/65` executes the api-extension function and passes the value `"/aquarium/water_limit/lower/set/65"` as the third parameter (`request_url`) into the api-extension function
 
 ### Get data about the board
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ You can also define your own functions in your sketch that can be called using t
 
 ### API-Extensions
 
-You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& command)`. For example, if your aREST instance is called "rest" and the function "aquariumController":
+You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& request_url)`. For example, if your aREST instance is called "rest" and the function "aquariumController":
   * `rest.api_extension("aquarium",aquariumController);` declares the api extension in the Arduino sketch
   * `/aquarium/water_limit/lower/set/65` executes the api-extionsion function
 

--- a/aREST.h
+++ b/aREST.h
@@ -1481,8 +1481,12 @@ bool send_command(bool headers, bool decodeArgs) {
       addHandlerToBuffer(value, request_url);
     } else {
       addToBufferF(F("{"));
+      auto bufferPos = index;
       addHandlerToBuffer(value, request_url);
-      addToBufferF(F(", "));
+      if (bufferPos < index) {
+        // index has changed -> the handler added some stuff to the buffer
+        addToBufferF(F(", "));
+      }
     }
   }
 

--- a/aREST.h
+++ b/aREST.h
@@ -133,6 +133,36 @@
 #define LIGHTWEIGHT 0
 #endif
 
+
+// -------- for backwards compatibility --------
+#ifdef AREST_NUMBER_VARIABLES
+#define NUMBER_VARIABLES AREST_NUMBER_VARIABLES
+#endif
+
+#ifdef AREST_NUMBER_FUNCTIONS
+#define NUMBER_FUNCTIONS AREST_NUMBER_FUNCTIONS
+#endif
+
+#if defined(NUMBER_VARIABLES) && defined(NUMBER_FUNCTIONS)
+  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
+#elif defined(NUMBER_VARIABLES)
+  #if defined(__AVR_ATmega1280__) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)
+  #define NUMBER_FUNCTIONS 10
+  #else
+  #define NUMBER_FUNCTIONS 5
+  #endif
+  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
+#elif defined(NUMBER_FUNCTIONS)
+  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
+  #define NUMBER_VARIABLES 10
+  #else
+  #define NUMBER_VARIABLES 5
+  #endif
+  #define AREST_NUMBER_HANDLERS (NUMBER_VARIABLES + NUMBER_FUNCTIONS)
+#endif
+// -------- end --------
+
+
 #ifdef AREST_NUMBER_HANDLERS
 #define NUMBER_HANDLERS AREST_NUMBER_HANDLERS
 #endif

--- a/aREST.h
+++ b/aREST.h
@@ -204,9 +204,8 @@ struct FunctionHandler: Handler {
     int result = func(arguments);
 
     if (!LIGHTWEIGHT) {
-      arest->addToBufferF(F("{\"return_value\": "));
+      arest->addToBufferF(F("\"return_value\": "));
       arest->addToBuffer(result, true);
-      arest->addToBufferF(F(", "));
       // arest->addToBufferF(F(", \"message\": \""));
       // arest->addStringToBuffer(name.c_str());
       // arest->addToBufferF(F(" executed\", "));

--- a/aREST.h
+++ b/aREST.h
@@ -286,7 +286,7 @@ void function(const char *name, int (*f)(String)) {
 }
 
 
-void api_handler(const char *name, void (*f)(aREST *, const String&, const String&)) {
+void api_extension(const char *name, void (*f)(aREST *, const String&, const String&)) {
   handlers[handlers_index] = new ApiHandler(f);
   handler_names[handlers_index] = name;
   handlers_index++;

--- a/aREST.h
+++ b/aREST.h
@@ -216,7 +216,7 @@ struct FunctionHandler: Handler {
   String extractParams(const String& name, const String& request_url) const {
     // We're expecting a string of the form <handlerName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
     // Get command -- Anything following the first '=' in answer will be put in the arguments string.
-    uint16_t header_length = name.length();
+    uint16_t header_length = name.length() + 1; // +1 for the '/' at the start
     if (request_url.substring(header_length, header_length + 1) == "?") {
       // Standard operation --> strip off anything preceeding the first "=", pass the rest to the handler
       if(AREST_PARAMS_MODE == 0) {

--- a/aREST.h
+++ b/aREST.h
@@ -133,29 +133,16 @@
 #define LIGHTWEIGHT 0
 #endif
 
-#ifdef AREST_NUMBER_VARIABLES
-#define NUMBER_VARIABLES AREST_NUMBER_VARIABLES
-#endif
-
-#ifdef AREST_NUMBER_FUNCTIONS
-#define NUMBER_FUNCTIONS AREST_NUMBER_FUNCTIONS
+#ifdef AREST_NUMBER_HANDLERS
+#define NUMBER_HANDLERS AREST_NUMBER_HANDLERS
 #endif
 
 // Default number of max. exposed variables
-#ifndef NUMBER_VARIABLES
+#ifndef NUMBER_HANDLERS
   #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
-  #define NUMBER_VARIABLES 10
+  #define NUMBER_HANDLERS 20
   #else
-  #define NUMBER_VARIABLES 5
-  #endif
-#endif
-
-// Default number of max. exposed functions
-#ifndef NUMBER_FUNCTIONS
-  #if defined(__AVR_ATmega1280__) || defined(ESP32) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)
-  #define NUMBER_FUNCTIONS 10
-  #else
-  #define NUMBER_FUNCTIONS 5
+  #define NUMBER_HANDLERS 10
   #endif
 #endif
 
@@ -168,13 +155,29 @@
 class aREST {
 
 private:
-struct Variable {
-  virtual void addToBuffer(aREST *arest) const = 0;
+struct Handler {
+  virtual void addToBuffer(aREST *arest, const String& name, const String& arguments) const = 0;
 };
 
 
-template<typename T>
-struct TypedVariable: Variable {
+template<bool INCLUDE_INTO_ROOT_ANSWER>
+struct RootVariable: Handler {
+  virtual void addToBuffer(aREST *arest) const = 0;
+
+  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+    if (LIGHTWEIGHT) {
+      addToBuffer(arest);
+    } else {
+      arest->addStringToBuffer(name.c_str(), true);
+      arest->addToBufferF(F(": "));
+      addToBuffer(arest);
+    }
+  }
+};
+
+
+template<typename T, bool INCLUDE_INTO_ROOT_ANSWER>
+struct TypedVariable: RootVariable<INCLUDE_INTO_ROOT_ANSWER> {
   T *var;
   bool quotable;
 
@@ -183,6 +186,26 @@ struct TypedVariable: Variable {
   void addToBuffer(aREST *arest) const override { 
     arest->addToBuffer(*var, quotable);
   }  
+};
+
+
+struct FunctionHandler: Handler {
+  int (*func)(String);
+
+  FunctionHandler(int (*f)(String)) : func{f} { }
+
+  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+    int result = func(arguments);
+
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("{\"return_value\": "));
+      arest->addToBuffer(result, true);
+      arest->addToBufferF(F(", "));
+      // arest->addToBufferF(F(", \"message\": \""));
+      // arest->addStringToBuffer(name.c_str());
+      // arest->addToBufferF(F(" executed\", "));
+    }
+  }
 };
 
 public:
@@ -209,14 +232,21 @@ aREST(char* rest_remote_server, int rest_port) {
 
 template<typename T>
 void variable(const char *name, T *var, bool quotable) { 
-  variables[variables_index] = new TypedVariable<T>(var, quotable);
-  variable_names[variables_index] = name;
-  variables_index++;
+  handlers[handlers_index] = new TypedVariable<T, true>(var, quotable);
+  handler_names[handlers_index] = name;
+  handlers_index++;
 }
 
 template<typename T>
 void variable(const char *name, T *var) { 
   variable(name, var, true);
+}
+
+
+void function(const char *name, int (*f)(String)) {
+  handlers[handlers_index] = new FunctionHandler(f);
+  handler_names[handlers_index] = name;
+  handlers_index++;
 }
 
 
@@ -1079,55 +1109,39 @@ void process(char c) {
     #endif
   }
 
-  // Variable or function request received ?
+  // Handler request received ?
   if (command == 'u') {
 
-    // Check if variable name is in int array
-    for (uint8_t i = 0; i < variables_index; i++) {
-      if (answer.startsWith(variable_names[i])) {
+    // Check if handler name is register in array
+    for (uint8_t i = 0; i < handlers_index; i++) {
+      if (answer.startsWith(handler_names[i])) {
 
         // End here
         pin_selected = true;
         state = 'x';
 
         // Set state
-        command = 'v';
-        value = i;
-
-        break; // We found what we're looking for
-      }
-    }
-
-    // Check if function name is in array
-    for (uint8_t i = 0; i < functions_index; i++) {
-      if (answer.startsWith(functions_names[i])) {
-
-        // End here
-        pin_selected = true;
-        state = 'x';
-
-        // Set state
-        command = 'f';
+        command = 'h';
         value = i;
 
         answer.trim();
 
-        // We're expecting a string of the form <functionName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
+        // We're expecting a string of the form <handlerName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
         // Get command -- Anything following the first '=' in answer will be put in the arguments string.
         arguments = "";
-        uint16_t header_length = strlen(functions_names[i]);
+        uint16_t header_length = strlen(handler_names[i]);
         if (answer.substring(header_length, header_length + 1) == "?") {
           uint16_t footer_start = answer.length();
           if (answer.endsWith(" HTTP/"))
             footer_start -= 6; // length of " HTTP/"
 
-          // Standard operation --> strip off anything preceeding the first "=", pass the rest to the function
+          // Standard operation --> strip off anything preceeding the first "=", pass the rest to the handler
           if(AREST_PARAMS_MODE == 0) {
             uint16_t eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
             if (eq_position != -1)
               arguments = answer.substring(eq_position + 1, footer_start);
           } 
-          // All params mode --> pass all parameters, if any, to the function.  Function will be resonsible for parsing
+          // All params mode --> pass all parameters, if any, to the handler.  Handler will be resonsible for parsing
           else if(AREST_PARAMS_MODE == 1) {
             arguments = answer.substring(header_length + 1, footer_start);
           }
@@ -1396,34 +1410,18 @@ bool send_command(bool headers, bool decodeArgs) {
     }
   }
 
-  // Variable selected
-  if (command == 'v') {
+  // Handler selected
+  if (command == 'h') {
+    if (decodeArgs) {
+      urldecode(arguments); // Modifies arguments
+    }
     // Send feedback to client
     if (LIGHTWEIGHT) {
-      variables[value]->addToBuffer(this);
+      addHandlerToBuffer(value, arguments);
     } else {
       addToBufferF(F("{"));
-      addVariableToBuffer(value);
-    }
-  }
-
-  // Function selected
-  if (command == 'f') {
-
-    // Execute function
-    if (decodeArgs)
-      urldecode(arguments); // Modifies arguments
-
-    int result = functions[value](arguments);
-
-    // Send feedback to client
-    if (!LIGHTWEIGHT) {
-      addToBufferF(F("{\"return_value\": "));
-      addToBuffer(result, true);
+      addHandlerToBuffer(value, arguments);
       addToBufferF(F(", "));
-      // addToBufferF(F(", \"message\": \""));
-      // addToBufferF(functions_names[value]);
-      // addToBufferF(F(" executed\", "));
     }
   }
 
@@ -1482,13 +1480,16 @@ virtual void root_answer() {
   else {
     addToBufferF(F("{\"variables\": {"));
 
-    for (uint8_t i = 0; i < variables_index; i++){
-      addStringToBuffer(variable_names[i], true);
-      addToBufferF(F(": "));
-      variables[i]->addToBuffer(this);
-
-      if (i < variables_index - 1) {
-        addToBufferF(F(", "));
+    bool isFirst = true;
+    for (uint8_t i = 0; i < handlers_index; i++){
+      if (dynamic_cast<RootVariable<true>*>(handlers[i])) {
+        // variable should be included into root answer
+        if (isFirst) {
+          isFirst = false;
+        } else {
+          addToBufferF(F(", "));
+        }
+        addHandlerToBuffer(i, String(""));
       }
     }
 
@@ -1503,13 +1504,6 @@ virtual void root_answer() {
   #endif
 }
 
-
-void function(char * function_name, int (*f)(String)){
-
-  functions_names[functions_index] = function_name;
-  functions[functions_index] = f;
-  functions_index++;
-}
 
 // Set device ID
 void set_id(const String& device_id) {
@@ -1842,11 +1836,8 @@ uint8_t esp_12_pin_map(uint8_t pin) {
 }
 
 
-void addVariableToBuffer(uint8_t index) {
-  addStringToBuffer(variable_names[index], true);
-  addToBufferF(F(": "));
-  variables[index]->addToBuffer(this);
-  addToBufferF(F(", "));
+void addHandlerToBuffer(uint8_t index, const String& arguments) {
+  handlers[index]->addToBuffer(this, String(handler_names[index]), arguments);
 }
 
 
@@ -1907,10 +1898,10 @@ private:
   // Status LED
   uint8_t status_led_pin;
 
-  // Int variables arrays
-  uint8_t variables_index;
-  Variable* variables[NUMBER_VARIABLES];
-  const char * variable_names[NUMBER_VARIABLES];
+  // Handlers arrays
+  uint8_t handlers_index;
+  Handler* handlers[NUMBER_HANDLERS];
+  const char * handler_names[NUMBER_HANDLERS];
 
   // MQTT client
   #if defined(PubSubClient_h)
@@ -1931,11 +1922,6 @@ private:
 
   #endif
 
-
-  // Functions array
-  uint8_t functions_index;
-  int (*functions[NUMBER_FUNCTIONS])(String);
-  char * functions_names[NUMBER_FUNCTIONS];
 
   // Memory debug
   #if defined(ESP8266) || defined(ESP32)

--- a/aREST.h
+++ b/aREST.h
@@ -137,7 +137,7 @@
 #define NUMBER_HANDLERS AREST_NUMBER_HANDLERS
 #endif
 
-// Default number of max. exposed variables
+// Default number of max. exposed handlers
 #ifndef NUMBER_HANDLERS
   #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266)|| defined(ESP32) || !defined(ADAFRUIT_CC3000_H)
   #define NUMBER_HANDLERS 20

--- a/aREST.h
+++ b/aREST.h
@@ -1155,7 +1155,7 @@ void process(char c) {
   // Handler request received ?
   if (command == 'u') {
 
-    if (answer.endsWith(" HTTP/")) {
+    if (answer.endsWith(" HTTP/") || answer.endsWith("\r")) {
       // Check if handler name is register in array
       for (uint8_t i = 0; i < handlers_index; i++) {
         if (answer.startsWith(handler_names[i])) {
@@ -1168,7 +1168,13 @@ void process(char c) {
           command = 'h';
           value = i;
 
-          request_url = "/" + answer.substring(0, answer.length() - 6); // length of " HTTP/"
+          answer.trim();
+
+          if (answer.endsWith(" HTTP/")) {
+            request_url = "/" + answer.substring(0, answer.length() - 6); // length of " HTTP/"
+          } else {
+            request_url = "/" + answer;
+          }
 
           break; // We found what we're looking for
         }
@@ -1210,7 +1216,7 @@ void process(char c) {
     answer = "";
   }
 
-  if (c == '\r' || answer.startsWith("GET /")) {
+  if (c == '\r' || answer.startsWith("GET /") || answer.startsWith("/")) {
     answer = "";
   }
 }

--- a/aREST.h
+++ b/aREST.h
@@ -1168,8 +1168,6 @@ void process(char c) {
           command = 'h';
           value = i;
 
-          answer.trim();
-
           request_url = "/" + answer.substring(0, answer.length() - 6); // length of " HTTP/"
 
           break; // We found what we're looking for

--- a/aREST.h
+++ b/aREST.h
@@ -161,7 +161,7 @@ struct Handler {
   Handler() : include_into_root_answer{false} { }
   Handler(bool include) : include_into_root_answer{include} { }
 
-  virtual void addToBuffer(aREST *arest, const String& name, const String& arguments) const = 0;
+  virtual void addToBuffer(aREST *arest, const String& name, const String& request_url) const = 0;
 };
 
 
@@ -170,7 +170,7 @@ struct Variable: Handler {
 
   virtual void addToBuffer(aREST *arest) const = 0;
 
-  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+  void addToBuffer(aREST *arest, const String& name, const String& request_url) const override {
     if (LIGHTWEIGHT) {
       addToBuffer(arest);
     } else {
@@ -200,7 +200,8 @@ struct FunctionHandler: Handler {
 
   FunctionHandler(int (*f)(String)) : func{f} { }
 
-  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+  void addToBuffer(aREST *arest, const String& name, const String& request_url) const override {
+    String arguments = extractParams(name, request_url);
     int result = func(arguments);
 
     if (!LIGHTWEIGHT) {
@@ -211,6 +212,25 @@ struct FunctionHandler: Handler {
       // arest->addToBufferF(F(" executed\", "));
     }
   }
+
+  String extractParams(const String& name, const String& request_url) const {
+    // We're expecting a string of the form <handlerName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
+    // Get command -- Anything following the first '=' in answer will be put in the arguments string.
+    uint16_t header_length = name.length();
+    if (request_url.substring(header_length, header_length + 1) == "?") {
+      // Standard operation --> strip off anything preceeding the first "=", pass the rest to the handler
+      if(AREST_PARAMS_MODE == 0) {
+        uint16_t eq_position = request_url.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
+        if (eq_position != -1)
+          return request_url.substring(eq_position + 1, request_url.length());
+      } 
+      // All params mode --> pass all parameters, if any, to the handler.  Handler will be resonsible for parsing
+      else if(AREST_PARAMS_MODE == 1) {
+        return request_url.substring(header_length + 1, request_url.length());
+      }
+    }
+    return String("");
+  }
 };
 
 
@@ -219,8 +239,8 @@ struct ApiHandler: Handler {
 
   ApiHandler(void (*f)(aREST *, const String&, const String&)) : func{f} { }
 
-  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
-    func(arest, name, arguments);
+  void addToBuffer(aREST *arest, const String& name, const String& request_url) const override {
+    func(arest, name, request_url);
   }
 };
 
@@ -448,7 +468,7 @@ void reset_status() {
 
   reset();
   answer = "";
-  arguments = "";
+  request_url = "";
 
   index = 0;
   //memset(&buffer[0], 0, sizeof(buffer));
@@ -1149,26 +1169,11 @@ void process(char c) {
 
         answer.trim();
 
-        // We're expecting a string of the form <handlerName>?xxxxx=<arguments>, where xxxxx can be almost anything as long as it's followed by an '='
-        // Get command -- Anything following the first '=' in answer will be put in the arguments string.
-        arguments = "";
-        uint16_t header_length = strlen(handler_names[i]);
-        if (answer.substring(header_length, header_length + 1) == "?") {
-          uint16_t footer_start = answer.length();
-          if (answer.endsWith(" HTTP/"))
-            footer_start -= 6; // length of " HTTP/"
-
-          // Standard operation --> strip off anything preceeding the first "=", pass the rest to the handler
-          if(AREST_PARAMS_MODE == 0) {
-            uint16_t eq_position = answer.indexOf('=', header_length); // Replacing 'magic number' 8 for fixed location of '='
-            if (eq_position != -1)
-              arguments = answer.substring(eq_position + 1, footer_start);
-          } 
-          // All params mode --> pass all parameters, if any, to the handler.  Handler will be resonsible for parsing
-          else if(AREST_PARAMS_MODE == 1) {
-            arguments = answer.substring(header_length + 1, footer_start);
-          }
-        }
+      if (answer.endsWith(" HTTP/")) {
+        request_url = "/" + answer.substring(0, answer.length() - 6); // length of " HTTP/"
+      } else {
+        request_url = "/" + answer;
+      }
 
         break; // We found what we're looking for
       }
@@ -1211,13 +1216,13 @@ void process(char c) {
 }
 
 
-// Modifies arguments in place
-void urldecode(String &arguments) {
+// Modifies request_url in place
+void urldecode(String &request_url) {
   char a, b;
   int j = 0;
-  for(int i = 0; i < arguments.length(); i++) {
-    // %20 ==> arguments[i] = '%', a = '2', b = '0'
-    if ((arguments[i] == '%') && ((a = arguments[i + 1]) && (b = arguments[i + 2])) && (isxdigit(a) && isxdigit(b))) {
+  for(int i = 0; i < request_url.length(); i++) {
+    // %20 ==> request_url[i] = '%', a = '2', b = '0'
+    if ((request_url[i] == '%') && ((a = request_url[i + 1]) && (b = request_url[i + 2])) && (isxdigit(a) && isxdigit(b))) {
       if (a >= 'a') a -= 'a'-'A';
       if (a >= 'A') a -= ('A' - 10);
       else          a -= '0';
@@ -1226,17 +1231,17 @@ void urldecode(String &arguments) {
       if (b >= 'A') b -= ('A' - 10);
       else          b -= '0';
 
-      arguments[j] = char(16 * a + b);
+      request_url[j] = char(16 * a + b);
       i += 2;   // Skip ahead
-    } else if (arguments[i] == '+') {
-      arguments[j] = ' ';
+    } else if (request_url[i] == '+') {
+      request_url[j] = ' ';
     } else {
-     arguments[j] = arguments[i];
+     request_url[j] = request_url[i];
     }
     j++;
   }
 
-  arguments.remove(j);    // Truncate string to new possibly reduced length
+  request_url.remove(j);    // Truncate string to new possibly reduced length
 }
 
 
@@ -1436,14 +1441,14 @@ bool send_command(bool headers, bool decodeArgs) {
   // Handler selected
   if (command == 'h') {
     if (decodeArgs) {
-      urldecode(arguments); // Modifies arguments
+      urldecode(request_url); // Modifies request_url
     }
     // Send feedback to client
     if (LIGHTWEIGHT) {
-      addHandlerToBuffer(value, arguments);
+      addHandlerToBuffer(value, request_url);
     } else {
       addToBufferF(F("{"));
-      addHandlerToBuffer(value, arguments);
+      addHandlerToBuffer(value, request_url);
       addToBufferF(F(", "));
     }
   }
@@ -1859,8 +1864,8 @@ uint8_t esp_12_pin_map(uint8_t pin) {
 }
 
 
-void addHandlerToBuffer(uint8_t index, const String& arguments) {
-  handlers[index]->addToBuffer(this, String(handler_names[index]), arguments);
+void addHandlerToBuffer(uint8_t index, const String& request_url) {
+  handlers[index]->addToBuffer(this, String(handler_names[index]), request_url);
 }
 
 
@@ -1912,7 +1917,7 @@ private:
 
   char name[NAME_SIZE];
   String id;
-  String arguments;
+  String request_url;
 
   // Output uffer
   char buffer[OUTPUT_BUFFER_SIZE];

--- a/aREST.h
+++ b/aREST.h
@@ -213,6 +213,17 @@ struct FunctionHandler: Handler {
   }
 };
 
+
+struct ApiHandler: Handler {
+  void (*func)(aREST *, const String&, const String&);
+
+  ApiHandler(void (*f)(aREST *, const String&, const String&)) : func{f} { }
+
+  void addToBuffer(aREST *arest, const String& name, const String& arguments) const override {
+    func(arest, name, arguments);
+  }
+};
+
 public:
 
 public:
@@ -250,6 +261,13 @@ void variable(const char *name, T *var) {
 
 void function(const char *name, int (*f)(String)) {
   handlers[handlers_index] = new FunctionHandler(f);
+  handler_names[handlers_index] = name;
+  handlers_index++;
+}
+
+
+void api_handler(const char *name, void (*f)(aREST *, const String&, const String&)) {
+  handlers[handlers_index] = new ApiHandler(f);
   handler_names[handlers_index] = name;
   handlers_index++;
 }

--- a/aREST.h
+++ b/aREST.h
@@ -1155,27 +1155,25 @@ void process(char c) {
   // Handler request received ?
   if (command == 'u') {
 
-    // Check if handler name is register in array
-    for (uint8_t i = 0; i < handlers_index; i++) {
-      if (answer.startsWith(handler_names[i])) {
+    if (answer.endsWith(" HTTP/")) {
+      // Check if handler name is register in array
+      for (uint8_t i = 0; i < handlers_index; i++) {
+        if (answer.startsWith(handler_names[i])) {
 
-        // End here
-        pin_selected = true;
-        state = 'x';
+          // End here
+          pin_selected = true;
+          state = 'x';
 
-        // Set state
-        command = 'h';
-        value = i;
+          // Set state
+          command = 'h';
+          value = i;
 
-        answer.trim();
+          answer.trim();
 
-      if (answer.endsWith(" HTTP/")) {
-        request_url = "/" + answer.substring(0, answer.length() - 6); // length of " HTTP/"
-      } else {
-        request_url = "/" + answer;
-      }
+          request_url = "/" + answer.substring(0, answer.length() - 6); // length of " HTTP/"
 
-        break; // We found what we're looking for
+          break; // We found what we're looking for
+        }
       }
     }
 
@@ -1210,9 +1208,13 @@ void process(char c) {
     //  Serial.print("Selected method: ");
     //  Serial.println(method);
     // }
+  } else {
+    answer = "";
   }
 
-  answer = "";
+  if (c == '\r' || answer.startsWith("GET /")) {
+    answer = "";
+  }
 }
 
 

--- a/examples/BLE/BLE.ino
+++ b/examples/BLE/BLE.ino
@@ -27,7 +27,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -96,10 +96,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -130,8 +130,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -140,8 +140,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/BLE/BLE.ino
+++ b/examples/BLE/BLE.ino
@@ -97,13 +97,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -136,9 +132,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/BLE/BLE.ino
+++ b/examples/BLE/BLE.ino
@@ -25,6 +25,10 @@ Adafruit_BLE_UART BTLEserial = Adafruit_BLE_UART(ADAFRUITBLE_REQ, ADAFRUITBLE_RD
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup(void)
 {
   // Start Serial
@@ -41,6 +45,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name & ID to the device (ID should be 6 characters long)
   rest.set_id("008");
@@ -87,4 +94,61 @@ int ledControl(String command) {
 
   digitalWrite(7,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/ESP32/ESP32.ino
+++ b/examples/ESP32/ESP32.ino
@@ -26,6 +26,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 void setup()
 {
@@ -41,6 +42,9 @@ void setup()
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name & ID to the device (ID should be 6 characters long)
   rest.set_id("1");
@@ -85,4 +89,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/ESP32/ESP32.ino
+++ b/examples/ESP32/ESP32.ino
@@ -26,7 +26,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup()
 {
@@ -91,10 +91,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -125,8 +125,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -135,8 +135,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/ESP32/ESP32.ino
+++ b/examples/ESP32/ESP32.ino
@@ -92,13 +92,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -131,9 +127,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/ESP32_cloud/ESP32_cloud.ino
+++ b/examples/ESP32_cloud/ESP32_cloud.ino
@@ -32,6 +32,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 // Functions
 void callback(char* topic, byte* payload, unsigned int length);
@@ -53,6 +54,9 @@ void setup()
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name & ID to the device (ID should be 6 characters long)
   rest.set_id(device_id);
@@ -91,4 +95,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/ESP32_cloud/ESP32_cloud.ino
+++ b/examples/ESP32_cloud/ESP32_cloud.ino
@@ -32,7 +32,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 // Functions
 void callback(char* topic, byte* payload, unsigned int length);
@@ -97,10 +97,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -131,8 +131,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -141,8 +141,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/ESP32_cloud/ESP32_cloud.ino
+++ b/examples/ESP32_cloud/ESP32_cloud.ino
@@ -98,13 +98,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -137,9 +133,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/ESP8266/ESP8266.ino
+++ b/examples/ESP8266/ESP8266.ino
@@ -28,6 +28,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 void setup(void)
 {
@@ -42,6 +43,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name & ID to the device (ID should be 6 characters long)
   rest.set_id("1");
@@ -86,4 +90,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/ESP8266/ESP8266.ino
+++ b/examples/ESP8266/ESP8266.ino
@@ -28,7 +28,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -92,10 +92,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -126,8 +126,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -136,8 +136,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/ESP8266/ESP8266.ino
+++ b/examples/ESP8266/ESP8266.ino
@@ -93,13 +93,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -132,9 +128,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/ESP8266_softAP/ESP8266_softAP.ino
+++ b/examples/ESP8266_softAP/ESP8266_softAP.ino
@@ -28,6 +28,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 void setup(void)
 {
@@ -42,6 +43,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name & ID to the device (ID should be 6 characters long)
   rest.set_id("1");
@@ -84,4 +88,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/ESP8266_softAP/ESP8266_softAP.ino
+++ b/examples/ESP8266_softAP/ESP8266_softAP.ino
@@ -91,13 +91,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -130,9 +126,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/ESP8266_softAP/ESP8266_softAP.ino
+++ b/examples/ESP8266_softAP/ESP8266_softAP.ino
@@ -28,7 +28,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -90,10 +90,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -124,8 +124,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -134,8 +134,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/Ethernet/Ethernet.ino
+++ b/examples/Ethernet/Ethernet.ino
@@ -30,7 +30,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -87,10 +87,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -121,8 +121,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -131,8 +131,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/Ethernet/Ethernet.ino
+++ b/examples/Ethernet/Ethernet.ino
@@ -88,13 +88,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -127,9 +123,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/Ethernet/Ethernet.ino
+++ b/examples/Ethernet/Ethernet.ino
@@ -28,6 +28,10 @@ aREST rest = aREST();
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup(void)
 {
   // Start Serial
@@ -41,6 +45,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name & ID to the device (ID should be 6 characters long)
   rest.set_id("008");
@@ -78,4 +85,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/MKR1000/MKR1000.ino
+++ b/examples/MKR1000/MKR1000.ino
@@ -32,6 +32,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 void setup(void)
 {
@@ -46,6 +47,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id("1");
@@ -94,4 +98,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/MKR1000/MKR1000.ino
+++ b/examples/MKR1000/MKR1000.ino
@@ -32,7 +32,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -100,10 +100,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -134,8 +134,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -144,8 +144,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/MKR1000/MKR1000.ino
+++ b/examples/MKR1000/MKR1000.ino
@@ -101,13 +101,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -140,9 +136,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/MKR1000_cloud/MKR1000_cloud.ino
+++ b/examples/MKR1000_cloud/MKR1000_cloud.ino
@@ -34,6 +34,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 // Callback function for the cloud connection
 void callback(char* topic, byte* payload, unsigned int length);
@@ -54,6 +55,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id(device_id);
@@ -87,6 +91,63 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }
 
 

--- a/examples/MKR1000_cloud/MKR1000_cloud.ino
+++ b/examples/MKR1000_cloud/MKR1000_cloud.ino
@@ -34,7 +34,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 // Callback function for the cloud connection
 void callback(char* topic, byte* payload, unsigned int length);
@@ -93,10 +93,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -127,8 +127,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -137,8 +137,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/MKR1000_cloud/MKR1000_cloud.ino
+++ b/examples/MKR1000_cloud/MKR1000_cloud.ino
@@ -94,13 +94,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -133,9 +129,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/MKR1000_cloud_and_local/MKR1000_cloud_and_local.ino
+++ b/examples/MKR1000_cloud_and_local/MKR1000_cloud_and_local.ino
@@ -35,6 +35,7 @@ String local_ip = "";
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
 
 // Callback function for the cloud connection
 void callback(char* topic, byte* payload, unsigned int length);
@@ -62,6 +63,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id(device_id);
@@ -114,6 +118,63 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }
 
 

--- a/examples/MKR1000_cloud_and_local/MKR1000_cloud_and_local.ino
+++ b/examples/MKR1000_cloud_and_local/MKR1000_cloud_and_local.ino
@@ -121,13 +121,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -160,9 +156,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/MKR1000_cloud_and_local/MKR1000_cloud_and_local.ino
+++ b/examples/MKR1000_cloud_and_local/MKR1000_cloud_and_local.ino
@@ -35,7 +35,7 @@ String local_ip = "";
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 // Callback function for the cloud connection
 void callback(char* topic, byte* payload, unsigned int length);
@@ -120,10 +120,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -154,8 +154,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -164,8 +164,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/MKR1000_cloud_pro/MKR1000_cloud_pro.ino
+++ b/examples/MKR1000_cloud_pro/MKR1000_cloud_pro.ino
@@ -96,13 +96,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -135,9 +131,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/MKR1000_cloud_pro/MKR1000_cloud_pro.ino
+++ b/examples/MKR1000_cloud_pro/MKR1000_cloud_pro.ino
@@ -34,7 +34,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 // Callback function for the cloud connection
 void callback(char* topic, byte* payload, unsigned int length);
@@ -95,10 +95,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -129,8 +129,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -139,8 +139,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/Serial/Serial.ino
+++ b/examples/Serial/Serial.ino
@@ -19,7 +19,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -64,10 +64,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -98,8 +98,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -108,8 +108,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/Serial/Serial.ino
+++ b/examples/Serial/Serial.ino
@@ -65,13 +65,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -104,9 +100,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/Serial/Serial.ino
+++ b/examples/Serial/Serial.ino
@@ -17,6 +17,10 @@ aREST rest = aREST();
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup(void)
 {
   // Start Serial
@@ -30,6 +34,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id("2");
@@ -55,4 +62,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/WiFi/WiFi.ino
+++ b/examples/WiFi/WiFi.ino
@@ -26,6 +26,10 @@ WiFiServer server(80);
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup() {
 
   // Start Serial
@@ -38,6 +42,9 @@ void setup() {
   rest.variable("humidity",&humidity);
 
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id("008");
@@ -92,6 +99,63 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }
 
 void printWifiStatus() {

--- a/examples/WiFi/WiFi.ino
+++ b/examples/WiFi/WiFi.ino
@@ -28,7 +28,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup() {
 
@@ -101,10 +101,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -135,8 +135,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -145,8 +145,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/WiFi/WiFi.ino
+++ b/examples/WiFi/WiFi.ino
@@ -102,13 +102,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -141,9 +137,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/WiFi_CC3000/WiFi_CC3000.ino
+++ b/examples/WiFi_CC3000/WiFi_CC3000.ino
@@ -41,6 +41,10 @@ MDNSResponder mdns;
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup(void)
 {
   // Start Serial
@@ -54,6 +58,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id("008");
@@ -137,4 +144,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/WiFi_CC3000/WiFi_CC3000.ino
+++ b/examples/WiFi_CC3000/WiFi_CC3000.ino
@@ -147,13 +147,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -186,9 +182,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/WiFi_CC3000/WiFi_CC3000.ino
+++ b/examples/WiFi_CC3000/WiFi_CC3000.ino
@@ -43,7 +43,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -146,10 +146,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -180,8 +180,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -190,8 +190,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/WiFi_CC3000_Due/WiFi_CC3000_Due.ino
+++ b/examples/WiFi_CC3000_Due/WiFi_CC3000_Due.ino
@@ -142,13 +142,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -181,9 +177,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/WiFi_CC3000_Due/WiFi_CC3000_Due.ino
+++ b/examples/WiFi_CC3000_Due/WiFi_CC3000_Due.ino
@@ -40,6 +40,10 @@ MDNSResponder mdns;
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup(void)
 {
   // Start Serial
@@ -53,6 +57,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device (ID should be 6 characters long)
   rest.set_id("1");
@@ -132,4 +139,61 @@ int ledControl(String command) {
 
   digitalWrite(6,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/examples/WiFi_CC3000_Due/WiFi_CC3000_Due.ino
+++ b/examples/WiFi_CC3000_Due/WiFi_CC3000_Due.ino
@@ -42,7 +42,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -141,10 +141,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -175,8 +175,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -185,8 +185,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/Yun/Yun.ino
+++ b/examples/Yun/Yun.ino
@@ -23,7 +23,7 @@ int humidity;
 
 // Declare functions to be exposed to the API
 int ledControl(String command);
-void aquariumController(aREST *arest, const String& name, const String& command);
+void aquariumController(aREST *arest, const String& name, const String& request_url);
 
 void setup(void)
 {
@@ -71,10 +71,10 @@ int ledControl(String command) {
   return 1;
 }
 
-void aquariumController(aREST *arest, const String& name, const String& command) {
-  // check format of command
-  if (command == F("/aquarium")
-      || command == F("/aquarium/")) {
+void aquariumController(aREST *arest, const String& name, const String& request_url) {
+  // check format of request_url
+  if (request_url == F("/aquarium")
+      || request_url == F("/aquarium/")) {
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -105,8 +105,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       }
       arest->addToBufferF(F("]"));
     }
-  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
-    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+  } else if (request_url.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = request_url.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
@@ -115,8 +115,8 @@ void aquariumController(aREST *arest, const String& name, const String& command)
       arest->addToBufferF(F("cm\""));
     }
   } else {
-    arest->addToBufferF(F("\"message\": \"Unknown command '"));
-    arest->addToBuffer(command);
+    arest->addToBufferF(F("\"message\": \"Unknown request_url '"));
+    arest->addToBuffer(request_url);
     arest->addToBufferF(F("'.\""));
   }
 }

--- a/examples/Yun/Yun.ino
+++ b/examples/Yun/Yun.ino
@@ -72,13 +72,9 @@ int ledControl(String command) {
 }
 
 void aquariumController(aREST *arest, const String& name, const String& command) {
-  Serial.print(F("============= controller: "));
-  Serial.println(command);
   // check format of command
   if (command == F("/aquarium")
       || command == F("/aquarium/")) {
-    Serial.println(F("list of sensors"));
-
     // Send feedback to client
     if (LIGHTWEIGHT) {
       bool isFirstSensor = true;
@@ -111,9 +107,6 @@ void aquariumController(aREST *arest, const String& name, const String& command)
     }
   } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
     String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
-
-    Serial.print(F("set lower water limit to "));
-    Serial.println(args);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {

--- a/examples/Yun/Yun.ino
+++ b/examples/Yun/Yun.ino
@@ -21,6 +21,10 @@ YunServer server(80);
 int temperature;
 int humidity;
 
+// Declare functions to be exposed to the API
+int ledControl(String command);
+void aquariumController(aREST *arest, const String& name, const String& command);
+
 void setup(void)
 {
   // Start Serial
@@ -34,6 +38,9 @@ void setup(void)
 
   // Function to be exposed
   rest.function("led",ledControl);
+
+  // API-Extension to be exposed
+  rest.api_extension("aquarium", aquariumController);
 
   // Give name and ID to device
   rest.set_id("008");
@@ -62,4 +69,61 @@ int ledControl(String command) {
 
   digitalWrite(7,state);
   return 1;
+}
+
+void aquariumController(aREST *arest, const String& name, const String& command) {
+  Serial.print(F("============= controller: "));
+  Serial.println(command);
+  // check format of command
+  if (command == F("/aquarium")
+      || command == F("/aquarium/")) {
+    Serial.println(F("list of sensors"));
+
+    // Send feedback to client
+    if (LIGHTWEIGHT) {
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(","));
+        }
+        auto id = i + 100;
+        arest->addToBuffer(id);
+      }
+    } else {
+      arest->addToBufferF(F("\"sensor-ids\": ["));
+      bool isFirstSensor = true;
+      auto count = 5;
+      for (uint32_t i = 0; i < count; ++i) {
+        if (isFirstSensor) {
+          isFirstSensor = false;
+        } else {
+          arest->addToBufferF(F(", "));
+        }
+        arest->addToBufferF(F("\""));
+        auto id = i + 100;
+        arest->addToBuffer(id);
+        arest->addToBufferF(F("\""));
+      }
+      arest->addToBufferF(F("]"));
+    }
+  } else if (command.startsWith(F("/aquarium/water_limit/lower/set/"))) {
+    String args = command.substring(32); // 32 = length of "/aquarium/water_limit/lower/set/"
+
+    Serial.print(F("set lower water limit to "));
+    Serial.println(args);
+
+    // Send feedback to client
+    if (!LIGHTWEIGHT) {
+      arest->addToBufferF(F("\"message\": \"lower water limit set to "));
+      arest->addToBuffer(args);
+      arest->addToBufferF(F("cm\""));
+    }
+  } else {
+    arest->addToBufferF(F("\"message\": \"Unknown command '"));
+    arest->addToBuffer(command);
+    arest->addToBufferF(F("'.\""));
+  }
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=aREST
-version=2.7.0
+version=2.7.1
 author=Marco Schwartz
 maintainer=Marco Schwartz <marcolivier.schwartz@gmail.com>
 sentence=RESTful API for the Arduino platform.

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,105 @@
+
+# Created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+# End of https://www.gitignore.io/api/python

--- a/test/http_test.py
+++ b/test/http_test.py
@@ -128,7 +128,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     # Call set of limit
     answer = json.loads(curl_call(target, "/aquarium/water_limit/lower/set/45"))
-    self.assertEqual(answer['message'], "lower limit set to 45cm")
+    self.assertEqual(answer['message'], "lower water limit set to 45cm")
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/http_test.py
+++ b/test/http_test.py
@@ -118,5 +118,17 @@ class TestSequenceFunctions(unittest.TestCase):
     answer = json.loads(curl_call(target,"/digital/6"))
     self.assertEqual(answer['return_value'],0)    
 
+  # API-Extension call check
+  def test_api_extension(self):
+
+    # Call list of sensors
+    answer = json.loads(curl_call(target, "/aquarium"))
+    l = [int(val) for val in answer['sensor-ids']]
+    self.assertEqual(l, [100, 101, 102, 103, 104])
+
+    # Call set of limit
+    answer = json.loads(curl_call(target, "/aquarium/water_limit/lower/set/45"))
+    self.assertEqual(answer['message'], "lower limit set to 45cm")
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/lightweight_test.py
+++ b/test/lightweight_test.py
@@ -83,5 +83,17 @@ class TestSequenceFunctions(unittest.TestCase):
     answer = curl_call(target,"/digital/6")
     self.assertEqual(int(answer),0)
 
+  # API-Extension call check
+  def test_api_extension(self):
+
+    # Call list of sensors
+    answer = curl_call(target, "/aquarium")
+    l = [int(val) for val in answer.split(',')]
+    self.assertEqual(l, [100, 101, 102, 103, 104])
+
+    # Call set of limit
+    answer = curl_call(target, "/aquarium/water_limit/lower/set/45")
+    self.assertEqual(answer.strip(), "")
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -104,7 +104,7 @@ class TestSequenceFunctions(unittest.TestCase):
     self.assertGreaterEqual(answer['temperature'],0)
     self.assertLessEqual(answer['temperature'],40)
 
-   # Function call check
+  # Function call check
   def test_function(self):
 
     # Call function
@@ -126,6 +126,20 @@ class TestSequenceFunctions(unittest.TestCase):
     self.serial.write("/digital/6\r")
     answer = json.loads(self.serial.readline())
     self.assertEqual(answer['return_value'],0)
+
+  # API-Extension call check
+  def test_api_extension(self):
+
+    # Call list of sensors
+    self.serial.write("/aquarium\r")
+    answer = json.loads(self.serial.readline())
+    l = [int(val) for val in answer['sensor-ids']]
+    self.assertEqual(l, [100, 101, 102, 103, 104])
+
+    # Call set of limit
+    self.serial.write("/aquarium/water_limit/lower/set/45\r")
+    answer = json.loads(self.serial.readline())
+    self.assertEqual(answer['message'], "lower water limit set to 45cm")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,
if you don't like the changes, don't mind and simply close this pull request 😄

This pull request builds upon pull request #238.

The possibility is added to extend the api by your own subcommands and customized responses.
The unit tests are also extended, and tested as far as I could do with my setup (Ethernet Shield on Arduino).
With my setup, all test run through now 😅 
The examples section is also updated with the new snippets.

I hope you feel comfortable with the changes.
If anything is not working, or you have other ideas, I'm looking forward to hearing from you.

The backwards compatibility of the API of the library is kept and the API can be used in the same way as before:
```
template<typename T>
void variable(const char *name, T *var, bool quotable);

void function(const char *name, int (*f)(String));
```

To explain the new functionality, I copied the updated README.md section below:

### API-Extensions

You can also define your api extensions in your sketch that can be called using the REST API. To access an user-defined api-extension defined in your sketch, you have to declare it first, and then call it from with a REST call. Note that all api-extension functions need to have the following signature `void api_extension(aREST *arest, const String& name, const String& request_url)`. For example, if your aREST instance is called "rest" and the function "aquariumController":

  * `rest.api_extension("aquarium",aquariumController);` declares the api extension in the Arduino sketch
  * `/aquarium/water_limit/lower/set/65` executes the api-extension function and passes the value `"/aquarium/water_limit/lower/set/65"` as the third parameter (`request_url`) into the api-extension function
  * You can then customize your JSON result and extend it to something like this:
    ```
    {
        "sensor-ids": ["100", "101", "102", "103", "104"],
        "id": "008",
        "name": "dapper_drake",
        "hardware": "arduino",
        "connected": true
    }
    ```