### PR TITLE
clear serial before starting the actual unit test

### DIFF
--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -18,6 +18,10 @@ class TestSequenceFunctions(unittest.TestCase):
     # Open Serial connection
     self.serial = serial.Serial(serial_port, serial_speed, timeout=1)
     time.sleep(2)
+    self.serial.write("\r\r")
+    time.sleep(0.1)
+    self.serial.reset_input_buffer()
+    self.serial.reset_output_buffer()
 
   # Mode basic test
   def test_mode(self):


### PR DESCRIPTION
Hi :)

this modification clears the serial before starting the actual unit test, because the Arduino is in an undefined state.

In my case the first unit test always failed, only on the second run it passed..