### PR TITLE
Registered functions return String instead of int

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -1487,12 +1487,12 @@ bool send_command(bool headers, bool decodeArgs) {
     if (decodeArgs)
       urldecode(arguments); // Modifies arguments
 
-    int result = functions[value](arguments);
+    String result = functions[value](arguments);
 
     // Send feedback to client
     if (!LIGHTWEIGHT) {
       addToBufferF(F("{\"return_value\": "));
-      addToBuffer(result, true);
+      addStringResultToBuffer(result.c_str(), true);
       addToBufferF(F(", "));
       // addToBufferF(F(", \"message\": \""));
       // addStringToBuffer(functions_names[value]);
@@ -1575,7 +1575,7 @@ virtual void root_answer() {
 }
 
 
-void function(char * function_name, int (*f)(String)){
+void function(char * function_name, String (*f)(String)){
 
   functions_names[functions_index] = function_name;
   functions[functions_index] = f;
@@ -1751,6 +1751,11 @@ void addToBuffer(T(*toAdd)(), bool quotable=true) {
   addToBuffer(toAdd(), quotable);
 } 
 
+// Register a function that allows the functions registered in the code to return String instead of int. It is more useful as a String can contain JSON or XML
+template <typename T>
+void addStringResultToBuffer(T toAdd, bool quotable=false) {
+  addStringToBuffer(String(toAdd).c_str(), false);   // Except for our overrides, this will be adding numbers, which don't get quoted
+}
 
 // // Add to output buffer
 // void addToBuffer(const __FlashStringHelper *toAdd, bool quotable){
@@ -2012,7 +2017,7 @@ private:
 
   // Functions array
   uint8_t functions_index;
-  int (*functions[NUMBER_FUNCTIONS])(String);
+  String (*functions[NUMBER_FUNCTIONS])(String);
   char * functions_names[NUMBER_FUNCTIONS];
 
   // Memory debug


### PR DESCRIPTION
Now registered function methods in the code return String instead of int. For instance, it would allow the responses to be more complex, now it can be returned a response containing String, int casted to String or even a JSON or XML. Therefore, it lets you reply with more than one simple integer.

E.g:

`void setup() {`
`.`
`.`
`.`
`  rest.function("test", testFunction);`
`}`

`String testFunction(String params) {`
`  String strJson= "{\"key1\" : \"value1\", \"key2\" : \"value2\"}";`
`  return strJson;`
`}`

I did a test with the following result:

![image](https://user-images.githubusercontent.com/8863071/79077293-32733000-7cc6-11ea-9415-4006486fc5f6.png)
